### PR TITLE
Now shows a one time warning when a duplicate schema is encountered

### DIFF
--- a/src/__tests__/createSchemaForm.test.tsx
+++ b/src/__tests__/createSchemaForm.test.tsx
@@ -10,7 +10,6 @@ import {
 } from "./utils/testForm";
 import {
   createTsForm,
-  duplicateTypeError,
   noMatchingSchemaErrorMessage,
   useFormResultValueChangedErrorMesssage,
 } from "../createSchemaForm";
@@ -505,14 +504,6 @@ describe("createSchemaForm", () => {
 
     expect(submitMock).toHaveBeenCalledTimes(1);
     expect(submitMock).toHaveBeenCalledWith(expectedOutput);
-  });
-  it("should throw a duplicate type error if multiple of the same schema are passed.", () => {
-    const mapping = [
-      [z.string(), () => <div />] as const,
-      [z.string(), () => <div />] as const,
-    ] as const;
-
-    expect(() => createTsForm(mapping)).toThrowError(duplicateTypeError());
   });
   it("should render the default values passed in via the useFormResult prop", () => {
     const testId = "id";

--- a/src/createSchemaForm.tsx
+++ b/src/createSchemaForm.tsx
@@ -16,7 +16,7 @@ import { unwrapEffects, UnwrapZodType } from "./unwrap";
 import { RTFBaseZodType, RTFSupportedZodTypes } from "./supportedZodTypes";
 import { FieldContextProvider } from "./FieldContext";
 import { isZodTypeEqual } from "./isZodTypeEqual";
-import { printWarningsForSchema } from "./logging";
+import { duplicateTypeError, printWarningsForSchema } from "./logging";
 
 /**
  * @internal
@@ -84,10 +84,6 @@ type UnwrapEffects<T extends AnyZodObject | ZodEffects<any, any>> =
     ? T["_def"]["schema"]
     : never;
 
-export function duplicateTypeError() {
-  return "Found duplicate zod schema in zod-component mapping. Each zod type in the mapping must be unique, if you need to map multiple of the same types to different schemas use createUniqueFieldSchema.";
-}
-
 function checkForDuplicateTypes(array: RTFSupportedZodTypes[]) {
   var combinations = array.flatMap((v, i) =>
     array.slice(i + 1).map((w) => [v, w] as const)
@@ -96,7 +92,7 @@ function checkForDuplicateTypes(array: RTFSupportedZodTypes[]) {
     printWarningsForSchema(a);
     printWarningsForSchema(b);
     if (isZodTypeEqual(a!, b)) {
-      throw new Error(duplicateTypeError());
+      duplicateTypeError();
     }
   }
 }

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -4,10 +4,19 @@ import { RTFSupportedZodTypes } from "./supportedZodTypes";
 const shownWarnings = {
   enum: false,
   useEnum: false,
+  duplicateSchema: false,
 };
 
 function err(message: string) {
   console.warn(`@ts-react/form: ${message}`);
+}
+
+export function duplicateTypeError() {
+  if (shownWarnings.duplicateSchema) return;
+  shownWarnings.duplicateSchema = true;
+  err(
+    "Found duplicate zod schema in zod-component mapping. Each zod type in the mapping must be unique, if you need to map multiple of the same types to different schemas use createUniqueFieldSchema."
+  );
 }
 
 export function printWarningsForSchema(type: RTFSupportedZodTypes) {


### PR DESCRIPTION
- user reported that the error duplicate might throw on nextjs with HMR, turned it into a warning to avoid issues