### PR TITLE
only pass enumValues to component when it has a value

### DIFF
--- a/src/createSchemaForm.tsx
+++ b/src/createSchemaForm.tsx
@@ -351,7 +351,7 @@ export function createTsForm<
           const mergedProps = {
             ...(propsMap.name && { [propsMap.name]: key }),
             ...(propsMap.control && { [propsMap.control]: control }),
-            ...(propsMap.enumValues && {
+            ...(propsMap.enumValues && !!meta.enumValues && {
               [propsMap.enumValues]: meta.enumValues,
             }),
             ...(propsMap.descriptionLabel && {


### PR DESCRIPTION
Hello there :D,

I get these annoying errors


Warning: React does not recognize the `enumValues` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `enumvalues` instead. If you accidentally passed it from a parent component, remove it from the DOM element.


This quick fix should do it.
