### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ The default behavior for this library is that errors will be shown once the user
 ```tsx
 const form = useForm<z.infer<typeof MyFormSchema>>({
   resolver: zodResolver(MyFormSchema),
-  revalidateMode: "onSubmit" // now the form revalidates on submit
+  reValidateMode: "onSubmit" // now the form revalidates on submit
 });
 
 return (


### PR DESCRIPTION
`revalidateMode` -> `reValidateMode` typo