### PR TITLE
clean: added specific return type for createUniqueFieldSchema

### DIFF
--- a/src/createFieldSchema.tsx
+++ b/src/createFieldSchema.tsx
@@ -1,3 +1,4 @@
+import { ZodBranded } from "zod";
 import { RTFSupportedZodTypes } from "./supportedZodTypes";
 
 export const HIDDEN_ID_PROPERTY = "_rtf_id";
@@ -21,7 +22,7 @@ export function isSchemaWithHiddenProperties<T extends RTFSupportedZodTypes>(
   return HIDDEN_ID_PROPERTY in schemaType;
 }
 
-export function addHiddenProperties<T extends RTFSupportedZodTypes>(
+function addHiddenProperties<T extends RTFSupportedZodTypes>(
   schema: T,
   properties: HiddenProperties
 ) {
@@ -57,7 +58,7 @@ export function duplicateIdErrorMessage(id: string) {
 export function createUniqueFieldSchema<
   T extends RTFSupportedZodTypes,
   Identifier extends string
->(schema: T, id: Identifier) {
-  const r = schema.brand<Identifier>();
+>(schema: T, id: Identifier): ZodBranded<T, Identifier> {
+  const r = schema.brand<Identifier>() as ZodBranded<T, Identifier>;
   return addHiddenProperties(r, { [HIDDEN_ID_PROPERTY]: id });
 }


### PR DESCRIPTION
Hello, 

I' ve found on my journey to migrate some inconvenience handling types. 
That's why I added this PR.

NOTE: This won't effect any functions or type errors, just makes it more readable.



```
const textAreaStringSchema = createUniqueFieldSchema(z.string(), "TextArea2");


// VSCode type examples after hovering 

// before change
const textAreaStringSchema: z.ZodBranded<z.ZodString, "TextArea2"> | z.ZodBranded<z.ZodNumber, "TextArea2"> | z.ZodBranded<z.ZodBoolean, "TextArea2"> | z.ZodBranded<z.ZodDate, "TextArea2"> | ... 11 more ... | z.ZodBranded<...>


// after change 
const textAreaStringSchema: z.ZodBranded<z.ZodString, "TextArea2">

```

EDIT: 

After creating the test file for #38 VSCode throws a ts error: 

```
The inferred type of this node exceeds the maximum length the compiler will serialize. An explicit type annotation is needed.
```

Applying this change, will **fix** this.