### PR TITLE
enable custom layouts and maybe inter-field conditional display

### DIFF
--- a/src/__tests__/createSchemaForm.test.tsx
+++ b/src/__tests__/createSchemaForm.test.tsx
@@ -69,6 +69,58 @@ describe("createSchemaForm", () => {
     expect(screen.queryByTestId(testIds.textFieldTwo)).toBeTruthy();
     expect(screen.queryByTestId(testIds.booleanField)).toBeTruthy();
   });
+  it("should render a text field and a boolean field based on the mapping and schema into slots in a custom form", () => {
+    const testSchema = z.object({
+      textField: z.string(),
+      textFieldTwo: z.string(),
+      booleanField: z.string(),
+      t: z.string(),
+      t2: z.string(),
+      t3: z.string(),
+      t4: z.string(),
+      t5: z.string(),
+    });
+
+    const extraTestIds = {
+      extra1 : 'extra-form-fun',
+      extra2 : 'extra-form-fun2'
+    }
+    render(
+      <TestForm
+        onSubmit={() => {}}
+        schema={testSchema}
+        props={{
+          textField: {
+            testId: testIds.textField,
+          },
+          textFieldTwo: {
+            testId: testIds.textFieldTwo,
+          },
+          booleanField: {
+            testId: testIds.booleanField,
+          },
+        }}
+      >
+        {({renderedFields : {textField, booleanField, ...restFields}}) => {
+          return <>
+            <div data-testid={extraTestIds.extra1}>
+              {textField}
+            </div>
+            <div data-testid={extraTestIds.extra2}>
+              {booleanField}
+            </div>
+            {Object.values(restFields)}
+          </>
+        }}
+      </TestForm>
+    );
+      
+    expect(screen.queryByTestId(testIds.textField)).toBeTruthy();
+    expect(screen.queryByTestId(testIds.textFieldTwo)).toBeTruthy();
+    expect(screen.queryByTestId(testIds.booleanField)).toBeTruthy();
+    expect(screen.queryByTestId(extraTestIds.extra1)).toBeTruthy();
+    expect(screen.queryByTestId(extraTestIds.extra2 )).toBeTruthy();
+  });
   it("should render a text field and a boolean field based on the mapping and schema, unwrapping refine calls", () => {
     const testSchema = z.object({
       textField: z.string(),


### PR DESCRIPTION
@iway1 
This turned out to be pretty easy to do. It's typed properly within the child component. I think a relatively easy follow on to this would be to pass the form values to this child to enable cross field conditional display / disabling etc ala https://github.com/iway1/react-ts-form/issues/34. (Maybe something like `useFormContext` within the ChildFormComponent could already accomplish this? but would be nice for it to be a bit better typed. Love to hear your thoughts on that)

I considered also passing all the renderedFieldNodes as children to the CustomChildComponent to allow this to work as just a simple body wrapper but i think `Object.values(renderedFields)` is pretty simple to do if someone really wants that use case. wdyt?

Closes https://github.com/iway1/react-ts-form/issues/54

cc: @gpeal @danielchiu