### PR TITLE
Recursive generation for objects and arrays

### DIFF
--- a/src/__tests__/createSchemaForm.test.tsx
+++ b/src/__tests__/createSchemaForm.test.tsx
@@ -1128,34 +1128,62 @@ describe("createSchemaForm", () => {
     const NumberSchema = createUniqueFieldSchema(z.number(), "number");
     const mockOnSubmit = jest.fn();
 
-    function TextField() {
-      const {
-        error,
-      } = useTsController<string>();
-      return <><div>text</div><div data-testid="error">{error?.errorMessage}</div></>;
+    function TextField({}: { b: "1" }) {
+      const { error } = useTsController<string>();
+      return (
+        <>
+          <div>text</div>
+          <div data-testid="error">{error?.errorMessage}</div>
+        </>
+      );
     }
 
-    function NumberField() {
+    function NumberField({}: { a: 1 }) {
       return <div>number</div>;
     }
+
+    function BooleanField({}: { c: boolean }) {
+      return <div>boolean</div>;
+    }
+
+    const objectSchema = z.object({
+      text: z.string(),
+      age: NumberSchema,
+    });
+    const objectSchema2 = z.object({
+      bool: z.boolean(),
+    });
 
     const mapping = [
       [z.string(), TextField],
       [NumberSchema, NumberField],
+      [z.boolean(), BooleanField],
+      [objectSchema2, BooleanField],
     ] as const;
 
     const Form = createTsForm(mapping);
 
     const schema = z.object({
-      nestedField: z.object({
-        name: z.string(),
-        age: NumberSchema,
-      })
+      nestedField: objectSchema,
+      nestedField2: objectSchema2,
     });
-    const defaultValues = { nestedField: { name: 'name', age: 9 } };
-    // TODO: test submit rolls up the values correctly
+    const defaultValues = {
+      nestedField: { text: "name", age: 9 },
+      nestedField2: { bool: true },
+    };
     // TODO: test validation
-    render(<Form schema={schema} onSubmit={mockOnSubmit} defaultValues={defaultValues} renderAfter={() => <button type="submit">submit</button>}/>);
+    render(
+      <Form
+        schema={schema}
+        onSubmit={mockOnSubmit}
+        defaultValues={defaultValues}
+        props={{
+          nestedField2: { c: true },
+          nestedField: { text: { b: "1" }, age: { a: 1 } },
+        }}
+        renderAfter={() => <button type="submit">submit</button>}
+      />
+    );
     const button = screen.getByText("submit");
     await userEvent.click(button);
 
@@ -1163,14 +1191,14 @@ describe("createSchemaForm", () => {
     expect(textNodes).toBeInTheDocument();
     const numberNodes = screen.queryByText("number");
     expect(numberNodes).toBeInTheDocument();
-    expect(screen.queryByTestId('error')).toHaveTextContent('');
+    expect(screen.queryByTestId("error")).toHaveTextContent("");
     expect(mockOnSubmit).toHaveBeenCalledWith(defaultValues);
   });
   it("should render two copies of an object schema if in an unmapped array schema", async () => {
     const NumberSchema = createUniqueFieldSchema(z.number(), "number");
     const mockOnSubmit = jest.fn();
 
-    function TextField() {
+    function TextField({}: { a?: 1 }) {
       return <div>text</div>;
     }
 
@@ -1186,21 +1214,45 @@ describe("createSchemaForm", () => {
     const Form = createTsForm(mapping);
 
     const schema = z.object({
-      arrayField: z.object({
-        name: z.string(),
-        age: NumberSchema,
-      }).array()
+      arrayField: z
+        .object({
+          text: z.string(),
+          age: NumberSchema,
+        })
+        .array(),
     });
     // TODO: test submit rolls up the values correctly
     // TODO: test validation
-    const defaultValues = { arrayField: [{ name: 'name', age: 9 }, { name: 'name2', age: 10 }] };
-    render(<Form schema={schema} onSubmit={mockOnSubmit} defaultValues={defaultValues} renderAfter={() => {
-      const form = useForm();
-      return <>
-      <div data-testid="errors">{JSON.stringify(form.formState.errors)}</div>
-      <button type="submit">submit</button>
-      </>
-    }}/>);
+    const defaultValues = {
+      arrayField: [
+        { text: "name", age: 9 },
+        { text: "name2", age: 10 },
+      ],
+    };
+    render(
+      <Form
+        schema={schema}
+        onSubmit={mockOnSubmit}
+        defaultValues={defaultValues}
+        props={{ arrayField: { text: { a: 1 } } }}
+        renderAfter={() => {
+          return <button type="submit">submit</button>;
+        }}
+      >
+        {({ renderedFields }) => {
+          return (
+            <>
+              {renderedFields.arrayField.map(({ text, age }) => (
+                <>
+                  {text}
+                  {age}
+                </>
+              ))}
+            </>
+          );
+        }}
+      </Form>
+    );
 
     const textNodes = screen.queryAllByText("text");
     textNodes.forEach((node) => expect(node).toBeInTheDocument());
@@ -1212,7 +1264,6 @@ describe("createSchemaForm", () => {
 
     const button = screen.getByText("submit");
     await userEvent.click(button);
-    console.log('errors', screen.queryByTestId('errors')?.textContent);
     expect(mockOnSubmit).toHaveBeenCalledWith(defaultValues);
   });
 });

--- a/src/__tests__/createSchemaForm.test.tsx
+++ b/src/__tests__/createSchemaForm.test.tsx
@@ -1166,7 +1166,7 @@ describe("createSchemaForm", () => {
     expect(screen.queryByTestId('error')).toHaveTextContent('');
     expect(mockOnSubmit).toHaveBeenCalledWith(defaultValues);
   });
-  xit("should render two copies of an object schema if in an unmapped array schema", () => {
+  it("should render two copies of an object schema if in an unmapped array schema", async () => {
     const NumberSchema = createUniqueFieldSchema(z.number(), "number");
     const mockOnSubmit = jest.fn();
 
@@ -1194,14 +1194,25 @@ describe("createSchemaForm", () => {
     // TODO: test submit rolls up the values correctly
     // TODO: test validation
     const defaultValues = { arrayField: [{ name: 'name', age: 9 }, { name: 'name2', age: 10 }] };
-    render(<Form schema={schema} onSubmit={mockOnSubmit} defaultValues={defaultValues} renderAfter={() => <button type="submit">submit</button>}/>);
+    render(<Form schema={schema} onSubmit={mockOnSubmit} defaultValues={defaultValues} renderAfter={() => {
+      const form = useForm();
+      return <>
+      <div data-testid="errors">{JSON.stringify(form.formState.errors)}</div>
+      <button type="submit">submit</button>
+      </>
+    }}/>);
 
     const textNodes = screen.queryAllByText("text");
-    expect(textNodes).toBeInTheDocument();
+    textNodes.forEach((node) => expect(node).toBeInTheDocument());
     expect(textNodes).toHaveLength(2);
+
     const numberNodes = screen.queryAllByText("number");
-    expect(numberNodes).toBeInTheDocument();
+    numberNodes.forEach((node) => expect(node).toBeInTheDocument());
     expect(numberNodes).toHaveLength(2);
+
+    const button = screen.getByText("submit");
+    await userEvent.click(button);
+    console.log('errors', screen.queryByTestId('errors')?.textContent);
     expect(mockOnSubmit).toHaveBeenCalledWith(defaultValues);
   });
 });

--- a/src/__tests__/createSchemaForm.test.tsx
+++ b/src/__tests__/createSchemaForm.test.tsx
@@ -1124,4 +1124,84 @@ describe("createSchemaForm", () => {
     expect(screen.queryByText("one")).toBeInTheDocument();
     expect(screen.queryByText("two")).toBeInTheDocument();
   });
+  it("should render the correct components for a nested object schema if unmaped", async () => {
+    const NumberSchema = createUniqueFieldSchema(z.number(), "number");
+    const mockOnSubmit = jest.fn();
+
+    function TextField() {
+      const {
+        error,
+      } = useTsController<string>();
+      return <><div>text</div><div data-testid="error">{error?.errorMessage}</div></>;
+    }
+
+    function NumberField() {
+      return <div>number</div>;
+    }
+
+    const mapping = [
+      [z.string(), TextField],
+      [NumberSchema, NumberField],
+    ] as const;
+
+    const Form = createTsForm(mapping);
+
+    const schema = z.object({
+      nestedField: z.object({
+        name: z.string(),
+        age: NumberSchema,
+      })
+    });
+    const defaultValues = { nestedField: { name: 'name', age: 9 } };
+    // TODO: test submit rolls up the values correctly
+    // TODO: test validation
+    render(<Form schema={schema} onSubmit={mockOnSubmit} defaultValues={defaultValues} renderAfter={() => <button type="submit">submit</button>}/>);
+    const button = screen.getByText("submit");
+    await userEvent.click(button);
+
+    const textNodes = screen.queryByText("text");
+    expect(textNodes).toBeInTheDocument();
+    const numberNodes = screen.queryByText("number");
+    expect(numberNodes).toBeInTheDocument();
+    expect(screen.queryByTestId('error')).toHaveTextContent('');
+    expect(mockOnSubmit).toHaveBeenCalledWith(defaultValues);
+  });
+  xit("should render two copies of an object schema if in an unmapped array schema", () => {
+    const NumberSchema = createUniqueFieldSchema(z.number(), "number");
+    const mockOnSubmit = jest.fn();
+
+    function TextField() {
+      return <div>text</div>;
+    }
+
+    function NumberField() {
+      return <div>number</div>;
+    }
+
+    const mapping = [
+      [z.string(), TextField],
+      [NumberSchema, NumberField],
+    ] as const;
+
+    const Form = createTsForm(mapping);
+
+    const schema = z.object({
+      arrayField: z.object({
+        name: z.string(),
+        age: NumberSchema,
+      }).array()
+    });
+    // TODO: test submit rolls up the values correctly
+    // TODO: test validation
+    const defaultValues = { arrayField: [{ name: 'name', age: 9 }, { name: 'name2', age: 10 }] };
+    render(<Form schema={schema} onSubmit={mockOnSubmit} defaultValues={defaultValues} renderAfter={() => <button type="submit">submit</button>}/>);
+
+    const textNodes = screen.queryAllByText("text");
+    expect(textNodes).toBeInTheDocument();
+    expect(textNodes).toHaveLength(2);
+    const numberNodes = screen.queryAllByText("number");
+    expect(numberNodes).toBeInTheDocument();
+    expect(numberNodes).toHaveLength(2);
+    expect(mockOnSubmit).toHaveBeenCalledWith(defaultValues);
+  });
 });

--- a/src/createSchemaForm.tsx
+++ b/src/createSchemaForm.tsx
@@ -14,7 +14,7 @@ import {
   useForm,
   UseFormReturn,
 } from "react-hook-form";
-import { AnyZodObject, z, ZodEffects } from "zod";
+import { AnyZodObject, z, ZodArray, ZodEffects, ZodFirstPartyTypeKind } from "zod";
 import { getComponentForZodType } from "./getComponentForZodType";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
@@ -45,7 +45,7 @@ export type ReactProps = Record<string, any>;
  */
 export type ReactComponentWithRequiredProps<
   Props extends ReactProps
-  // ExtraProps extends Record<string, any> = {}
+// ExtraProps extends Record<string, any> = {}
 > =
   | ((props: Props) => JSX.Element)
   | (ForwardRefExoticComponent<Props> & RefAttributes<unknown>);
@@ -94,7 +94,7 @@ export type ExtraProps = {
 /**
  * @internal
  */
-type UnwrapEffects<T extends AnyZodObject | ZodEffects<any, any>> =
+type UnwrapEffects<T extends RTFSupportedZodTypes | ZodEffects<any, any>> =
   T extends AnyZodObject
     ? T
     : T extends ZodEffects<infer EffectsSchema, any>
@@ -140,6 +140,42 @@ function propsMapToObect(propsMap: PropsMapping) {
   }
   return r;
 }
+
+export type PropType<
+  Mapping extends FormComponentMapping,
+  SchemaType extends RTFSupportedZodTypes | ZodEffects<any, any>,
+  PropsMapType extends PropsMapping = typeof defaultPropsMap,
+> = RequireKeysWithRequiredChildren<
+  Partial<{
+    [key in keyof z.infer<UnwrapEffects<SchemaType>>]: Mapping[IndexOf<
+      UnwrapMapping<Mapping>,
+      readonly [
+        IndexOfUnwrapZodType<
+          ReturnType<UnwrapEffects<SchemaType>["_def"]["shape"]>[key]
+        >,
+        any
+      ]
+    >] extends readonly [any, any] // I guess this tells typescript it has a second element? errors without this check.
+    ? Omit<
+      ComponentProps<
+        Mapping[IndexOf<
+          UnwrapMapping<Mapping>,
+          readonly [
+            IndexOfUnwrapZodType<
+              ReturnType<
+                UnwrapEffects<SchemaType>["_def"]["shape"]
+              >[key]
+            >,
+            any
+          ]
+        >][1]
+      >,
+      PropsMapType[number][1]
+    > &
+    ExtraProps
+    : never;
+  }>
+>
 
 /**
  * Creates a reusable, typesafe form component based on a zod-component mapping.
@@ -290,9 +326,15 @@ export function createTsForm<
     form?: UseFormReturn<z.infer<SchemaType>>;
     children?: FunctionComponent<{
       renderedFields: {
+<<<<<<< HEAD
         [key in keyof z.infer<UnwrapEffects<SchemaType>>]: ReactNode;
       };
     }>;
+=======
+        [key in keyof z.infer<UnwrapEffects<SchemaType>>]: ReactNode
+      }
+    }>
+>>>>>>> 4db54a1 (feat(field): recursive generation for fields)
   } & RequireKeysWithRequiredChildren<{
     /**
      * Props to pass to the individual form components. The keys of `props` will be the names of your form properties in the form schema, and they will
@@ -309,37 +351,7 @@ export function createTsForm<
      * />
      * ```
      */
-    props?: RequireKeysWithRequiredChildren<
-      Partial<{
-        [key in keyof z.infer<UnwrapEffects<SchemaType>>]: Mapping[IndexOf<
-          UnwrapMapping<Mapping>,
-          readonly [
-            IndexOfUnwrapZodType<
-              ReturnType<UnwrapEffects<SchemaType>["_def"]["shape"]>[key]
-            >,
-            any
-          ]
-        >] extends readonly [any, any] // I guess this tells typescript it has a second element? errors without this check.
-          ? Omit<
-              ComponentProps<
-                Mapping[IndexOf<
-                  UnwrapMapping<Mapping>,
-                  readonly [
-                    IndexOfUnwrapZodType<
-                      ReturnType<
-                        UnwrapEffects<SchemaType>["_def"]["shape"]
-                      >[key]
-                    >,
-                    any
-                  ]
-                >][1]
-              >,
-              PropsMapType[number][1]
-            > &
-              ExtraProps
-          : never;
-      }>
-    >;
+    props?: PropType<Mapping, SchemaType, PropsMapType>;
   }> &
     RequireKeysWithRequiredChildren<{
       /**
@@ -362,9 +374,9 @@ export function createTsForm<
       });
       return uf;
     })();
-    const { control, handleSubmit, setError } = _form;
-    const _schema = unwrapEffects(schema);
-    const shape: Record<string, RTFSupportedZodTypes> = _schema._def.shape();
+    const { control, handleSubmit, setError, } = _form;
+
+
     const coerceUndefinedFieldsRef = useRef<Set<string>>(new Set());
 
     function addToCoerceUndefined(fieldName: string) {
@@ -401,62 +413,100 @@ export function createTsForm<
       );
     }
     const submitFn = handleSubmit(_submit);
-    type SchemaKey = keyof z.infer<UnwrapEffects<SchemaType>>;
-    const renderedFields = Object.keys(shape).reduce(
-      (accum, key: SchemaKey) => {
+
+    const isAnyZodObject = (schema: RTFSupportedZodTypes): schema is AnyZodObject => schema._def.typeName === ZodFirstPartyTypeKind.ZodObject;
+    const isZodArray = (schema: RTFSupportedZodTypes): schema is ZodArray<any> => schema._def.typeName === ZodFirstPartyTypeKind.ZodArray;
+
+    type RenderedElement = JSX.Element | JSX.Element[] | RenderedObjectElements;
+    type RenderedObjectElements = { [key: string]: RenderedElement };
+
+
+    function renderComponentForSchema<NestedSchemaType extends RTFSupportedZodTypes | ZodEffects<any, any>>(
+      _type: NestedSchemaType, props: PropType<Mapping, NestedSchemaType, PropsMapType> | undefined, key: string, prefix: string
+    ): RenderedElement {
+      const prefixedKey = prefix ? `${prefix}.${key}` : key;
+      const type = unwrapEffects(_type);
+      const Component = getComponentForZodType(type, componentMap);
+      if (!Component) {
+        if (isAnyZodObject(type)) {
+          const shape: Record<string, RTFSupportedZodTypes> = type._def.shape();
+          return Object.entries(shape).reduce((accum, [subKey, subType]) => {
+            accum[subKey] = renderComponentForSchema(subType, props && props[subKey] ? (props[subKey] as any) : undefined, subKey, prefixedKey)
+            return accum;
+          }, {} as RenderedObjectElements)
+        }
+        if (isZodArray(type)) {
+          // TDOO: implement array rendering based on current field value
+        }
+        throw new Error(
+          noMatchingSchemaErrorMessage(key, type._def.typeName)
+        );
+      }
+      const meta = getMetaInformationForZodType(type);
+
+      const fieldProps = props && props[key] ? (props[key] as any) : {};
+
+      const { beforeElement, afterElement } = fieldProps;
+
+      const mergedProps = {
+        ...(propsMap.name && { [propsMap.name]: prefixedKey }),
+        ...(propsMap.control && { [propsMap.control]: control }),
+        ...(propsMap.enumValues && {
+          [propsMap.enumValues]: meta.enumValues,
+        }),
+        ...(propsMap.descriptionLabel && {
+          [propsMap.descriptionLabel]: meta.description?.label,
+        }),
+        ...(propsMap.descriptionPlaceholder && {
+          [propsMap.descriptionPlaceholder]: meta.description?.placeholder,
+        }),
+        ...fieldProps,
+      };
+      const ctxLabel = meta.description?.label;
+      const ctxPlaceholder = meta.description?.placeholder;
+
+      return (
+        <Fragment key={prefixedKey}>
+          {beforeElement}
+          <FieldContextProvider
+            control={control}
+            name={prefixedKey}
+            label={ctxLabel}
+            placeholder={ctxPlaceholder}
+            enumValues={meta.enumValues as string[] | undefined}
+            addToCoerceUndefined={addToCoerceUndefined}
+            removeFromCoerceUndefined={removeFromCoerceUndefined}
+          >
+            <Component key={prefixedKey} {...mergedProps} />
+          </FieldContextProvider>
+          {afterElement}
+        </Fragment>
+      );
+    }
+
+    function renderFields(schema: SchemaType, props: PropType<Mapping, SchemaType, PropsMapType> | undefined) {
+      type SchemaKey = keyof z.infer<UnwrapEffects<SchemaType>>;
+      const _schema = unwrapEffects(schema);
+      const shape: Record<string, RTFSupportedZodTypes> = _schema._def.shape();
+      return Object.entries(shape).reduce((accum, [key, type]: [SchemaKey, RTFSupportedZodTypes]) => {
         // we know this is a string but TS thinks it can be number and symbol so just in case stringify
         const stringKey = key.toString();
-        const type = shape[key] as RTFSupportedZodTypes;
-        const Component = getComponentForZodType(type, componentMap);
-        if (!Component) {
-          throw new Error(
-            noMatchingSchemaErrorMessage(stringKey, type._def.typeName)
-          );
-        }
-        const meta = getMetaInformationForZodType(type);
-
-        const fieldProps = props && props[key] ? (props[key] as any) : {};
-
-        const { beforeElement, afterElement } = fieldProps;
-
-        const mergedProps = {
-          ...(propsMap.name && { [propsMap.name]: key }),
-          ...(propsMap.control && { [propsMap.control]: control }),
-          ...(propsMap.enumValues && {
-            [propsMap.enumValues]: meta.enumValues,
-          }),
-          ...(propsMap.descriptionLabel && {
-            [propsMap.descriptionLabel]: meta.description?.label,
-          }),
-          ...(propsMap.descriptionPlaceholder && {
-            [propsMap.descriptionPlaceholder]: meta.description?.placeholder,
-          }),
-          ...fieldProps,
-        };
-        const ctxLabel = meta.description?.label;
-        const ctxPlaceholder = meta.description?.placeholder;
-        accum[key] = (
-          <Fragment key={stringKey}>
-            {beforeElement}
-            <FieldContextProvider
-              control={control}
-              name={stringKey}
-              label={ctxLabel}
-              placeholder={ctxPlaceholder}
-              enumValues={meta.enumValues as string[] | undefined}
-              addToCoerceUndefined={addToCoerceUndefined}
-              removeFromCoerceUndefined={removeFromCoerceUndefined}
-            >
-              <Component key={key} {...mergedProps} />
-            </FieldContextProvider>
-            {afterElement}
-          </Fragment>
-        );
+        accum[stringKey] = renderComponentForSchema(type, props, stringKey, '');
         return accum;
-      },
-      {} as Record<SchemaKey, React.ReactNode>
-    );
-    const renderedFieldNodes = Object.values(renderedFields);
+      }, {} as RenderedObjectElements);
+    }
+
+    const renderedFields = renderFields(schema, props);
+    function getObjectValues(obj: RenderedObjectElements): JSX.Element[] {
+      return Object.values(obj).reduce((accum: JSX.Element[], val) => {
+        return Array.isArray(val) ?
+          accum.concat(val)
+          : (typeof val === 'object' && val !== null && !React.isValidElement(val)) ?
+            accum.concat(getObjectValues(val as any))
+            : accum.concat([val])
+      }, [] as JSX.Element[]);
+    }
+    const renderedFieldNodes = getObjectValues(renderedFields);
     return (
       <FormProvider {..._form}>
         <ActualFormComponent {...formProps} onSubmit={submitFn}>

--- a/src/createSchemaForm.tsx
+++ b/src/createSchemaForm.tsx
@@ -14,7 +14,13 @@ import {
   useForm,
   UseFormReturn,
 } from "react-hook-form";
-import { AnyZodObject, z, ZodArray, ZodEffects, ZodFirstPartyTypeKind } from "zod";
+import {
+  AnyZodObject,
+  z,
+  ZodArray,
+  ZodEffects,
+  ZodFirstPartyTypeKind,
+} from "zod";
 import { getComponentForZodType } from "./getComponentForZodType";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
@@ -45,7 +51,7 @@ export type ReactProps = Record<string, any>;
  */
 export type ReactComponentWithRequiredProps<
   Props extends ReactProps
-// ExtraProps extends Record<string, any> = {}
+  // ExtraProps extends Record<string, any> = {}
 > =
   | ((props: Props) => JSX.Element)
   | (ForwardRefExoticComponent<Props> & RefAttributes<unknown>);
@@ -141,41 +147,165 @@ function propsMapToObect(propsMap: PropsMapping) {
   return r;
 }
 
+type SchemaShape<
+  SchemaType extends RTFSupportedZodTypes | ZodEffects<any, any>
+> = ReturnType<UnwrapEffects<SchemaType>["_def"]["shape"]>;
+
+type IndexOfSchemaInMapping<
+  Mapping extends FormComponentMapping,
+  SchemaType extends RTFSupportedZodTypes | ZodEffects<any, any>,
+  key extends keyof z.infer<UnwrapEffects<SchemaType>>
+> = IndexOf<
+  UnwrapMapping<Mapping>,
+  readonly [IndexOfUnwrapZodType<SchemaShape<SchemaType>[key]>, any]
+>;
+
+type GetTupleFromMapping<
+  Mapping extends FormComponentMapping,
+  SchemaType extends RTFSupportedZodTypes | ZodEffects<any, any>,
+  key extends keyof z.infer<UnwrapEffects<SchemaType>>
+> = IndexOfSchemaInMapping<Mapping, SchemaType, key> extends never
+  ? never
+  : Mapping[IndexOfSchemaInMapping<Mapping, SchemaType, key>];
+
+type Prev = [never, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 export type PropType<
   Mapping extends FormComponentMapping,
   SchemaType extends RTFSupportedZodTypes | ZodEffects<any, any>,
   PropsMapType extends PropsMapping = typeof defaultPropsMap,
-> = RequireKeysWithRequiredChildren<
-  Partial<{
-    [key in keyof z.infer<UnwrapEffects<SchemaType>>]: Mapping[IndexOf<
-      UnwrapMapping<Mapping>,
-      readonly [
-        IndexOfUnwrapZodType<
-          ReturnType<UnwrapEffects<SchemaType>["_def"]["shape"]>[key]
-        >,
-        any
-      ]
-    >] extends readonly [any, any] // I guess this tells typescript it has a second element? errors without this check.
-    ? Omit<
-      ComponentProps<
-        Mapping[IndexOf<
-          UnwrapMapping<Mapping>,
-          readonly [
-            IndexOfUnwrapZodType<
-              ReturnType<
-                UnwrapEffects<SchemaType>["_def"]["shape"]
-              >[key]
-            >,
-            any
-          ]
-        >][1]
-      >,
-      PropsMapType[number][1]
-    > &
-    ExtraProps
-    : never;
-  }>
->
+  // this controls the depth we allow TS to go into the schema. 2 is enough for most cases, but we could consider exposing this as a generic to allow users to control the depth
+  Level extends Prev[number] = 2
+> = [Level] extends [never]
+  ? never
+  : RequireKeysWithRequiredChildren<
+      Partial<{
+        [key in keyof z.infer<UnwrapEffects<SchemaType>>]: GetTupleFromMapping<
+          Mapping,
+          SchemaType,
+          key
+        > extends never
+          ? UnwrapEffects<SchemaType>["shape"][key] extends z.AnyZodObject
+            ? PropType<
+                Mapping,
+                UnwrapEffects<SchemaType>["shape"][key],
+                PropsMapType,
+                Prev[Level]
+              >
+            : UnwrapEffects<SchemaType>["shape"][key] extends z.ZodArray<any>
+            ? PropType<
+                Mapping,
+                UnwrapEffects<SchemaType>["shape"][key]["element"],
+                PropsMapType,
+                Prev[Level]
+              >
+            : never
+          : GetTupleFromMapping<Mapping, SchemaType, key> extends readonly [
+              any,
+              any
+            ] // I guess this tells typescript it has a second element? errors without this check.
+          ? Omit<
+              ComponentProps<GetTupleFromMapping<Mapping, SchemaType, key>[1]>,
+              PropsMapType[number][1]
+            > &
+              ExtraProps
+          : never;
+      }>
+    >;
+
+type RenderedFieldMap<SchemaType extends AnyZodObject | ZodEffects<any, any>> =
+  {
+    [key in keyof z.infer<
+      UnwrapEffects<SchemaType>
+    >]: UnwrapEffects<SchemaType>["shape"][key] extends z.AnyZodObject
+      ? RenderedFieldMap<UnwrapEffects<SchemaType>["shape"][key]>
+      : UnwrapEffects<SchemaType>["shape"][key] extends z.ZodArray<any>
+      ? UnwrapEffects<SchemaType>["shape"][key]["element"] extends z.AnyZodObject
+        ? RenderedFieldMap<UnwrapEffects<SchemaType>["shape"][key]["element"]>[]
+        : JSX.Element[]
+      : JSX.Element;
+  };
+
+type RTFFormProps<
+  Mapping extends FormComponentMapping,
+  SchemaType extends z.AnyZodObject | ZodEffects<any, any>,
+  PropsMapType extends PropsMapping = typeof defaultPropsMap,
+  FormType extends FormComponent = "form"
+> = {
+  /**
+   * A Zod Schema - An input field will be rendered for each property in the schema, based on the mapping passed to `createTsForm`
+   */
+  schema: SchemaType;
+  /**
+   * A callback function that will be called with the data once the form has been submitted and validated successfully.
+   */
+  onSubmit: (values: z.infer<SchemaType>) => void | Promise<void>;
+  /**
+   * Initializes your form with default values. Is a deep partial, so all properties and nested properties are optional.
+   */
+  defaultValues?: DeepPartial<z.infer<UnwrapEffects<SchemaType>>>;
+  /**
+   * A function that renders components after the form, the function is passed a `submit` function that can be used to trigger
+   * form submission.
+   * @example
+   * ```tsx
+   * <Form
+   *   // ...
+   *   renderAfter={({submit})=><button onClick={submit}>Submit</button>}
+   * />
+   * ```
+   */
+  renderAfter?: (vars: { submit: () => void }) => ReactNode;
+  /**
+   * A function that renders components before the form, the function is passed a `submit` function that can be used to trigger
+   * form submission.
+   * @example
+   * ```tsx
+   * <Form
+   *   // ...
+   *   renderBefore={({submit})=><button onClick={submit}>Submit</button>}
+   * />
+   * ```
+   */
+  renderBefore?: (vars: { submit: () => void }) => ReactNode;
+  /**
+   * Use this if you need access to the `react-hook-form` useForm() in the component containing the form component (if you need access to any of its other properties.)
+   * This will give you full control over you form state (in case you need check if it's dirty or reset it or anything.)
+   * @example
+   * ```tsx
+   * function Component() {
+   *   const form = useForm();
+   *   return <MyForm useFormResult={form}/>
+   * }
+   * ```
+   */
+  form?: UseFormReturn<z.infer<SchemaType>>;
+  children?: FunctionComponent<{
+    renderedFields: RenderedFieldMap<SchemaType>;
+  }>;
+} & RequireKeysWithRequiredChildren<{
+  /**
+   * Props to pass to the individual form components. The keys of `props` will be the names of your form properties in the form schema, and they will
+   * be typesafe to the form components in the mapping passed to `createTsForm`. If any of the rendered form components have required props, this is required.
+   * @example
+   * ```tsx
+   * <MyForm
+   *  schema={z.object({field: z.string()})}
+   *  props={{
+   *    field: {
+   *      // TextField props
+   *    }
+   *  }}
+   * />
+   * ```
+   */
+  props?: PropType<Mapping, SchemaType, PropsMapType>;
+}> &
+  RequireKeysWithRequiredChildren<{
+    /**
+     * Props to pass to the form container component (by default the props that "form" tags accept)
+     */
+    formProps?: Omit<ComponentProps<FormType>, "children" | "onSubmit">;
+  }>;
 
 /**
  * Creates a reusable, typesafe form component based on a zod-component mapping.
@@ -275,84 +405,7 @@ export function createTsForm<
     renderBefore,
     form,
     children: CustomChildrenComponent,
-  }: {
-    /**
-     * A Zod Schema - An input field will be rendered for each property in the schema, based on the mapping passed to `createTsForm`
-     */
-    schema: SchemaType;
-    /**
-     * A callback function that will be called with the data once the form has been submitted and validated successfully.
-     */
-    onSubmit: (values: z.infer<SchemaType>) => void | Promise<void>;
-    /**
-     * Initializes your form with default values. Is a deep partial, so all properties and nested properties are optional.
-     */
-    defaultValues?: DeepPartial<z.infer<UnwrapEffects<SchemaType>>>;
-    /**
-     * A function that renders components after the form, the function is passed a `submit` function that can be used to trigger
-     * form submission.
-     * @example
-     * ```tsx
-     * <Form
-     *   // ...
-     *   renderAfter={({submit})=><button onClick={submit}>Submit</button>}
-     * />
-     * ```
-     */
-    renderAfter?: (vars: { submit: () => void }) => ReactNode;
-    /**
-     * A function that renders components before the form, the function is passed a `submit` function that can be used to trigger
-     * form submission.
-     * @example
-     * ```tsx
-     * <Form
-     *   // ...
-     *   renderBefore={({submit})=><button onClick={submit}>Submit</button>}
-     * />
-     * ```
-     */
-    renderBefore?: (vars: { submit: () => void }) => ReactNode;
-    /**
-     * Use this if you need access to the `react-hook-form` useForm() in the component containing the form component (if you need access to any of its other properties.)
-     * This will give you full control over you form state (in case you need check if it's dirty or reset it or anything.)
-     * @example
-     * ```tsx
-     * function Component() {
-     *   const form = useForm();
-     *   return <MyForm useFormResult={form}/>
-     * }
-     * ```
-     */
-    form?: UseFormReturn<z.infer<SchemaType>>;
-    children?: FunctionComponent<{
-      renderedFields: {
-        [key in keyof z.infer<UnwrapEffects<SchemaType>>]: ReactNode;
-      };
-    }>;
-  } & RequireKeysWithRequiredChildren<{
-    /**
-     * Props to pass to the individual form components. The keys of `props` will be the names of your form properties in the form schema, and they will
-     * be typesafe to the form components in the mapping passed to `createTsForm`. If any of the rendered form components have required props, this is required.
-     * @example
-     * ```tsx
-     * <MyForm
-     *  schema={z.object({field: z.string()})}
-     *  props={{
-     *    field: {
-     *      // TextField props
-     *    }
-     *  }}
-     * />
-     * ```
-     */
-    props?: PropType<Mapping, SchemaType, PropsMapType>;
-  }> &
-    RequireKeysWithRequiredChildren<{
-      /**
-       * Props to pass to the form container component (by default the props that "form" tags accept)
-       */
-      formProps?: Omit<ComponentProps<FormType>, "children" | "onSubmit">;
-    }>) {
+  }: RTFFormProps<Mapping, SchemaType, PropsMapType, FormType>) {
     const useFormResultInitialValue = useRef<
       undefined | ReturnType<typeof useForm>
     >(form);
@@ -368,8 +421,7 @@ export function createTsForm<
       });
       return uf;
     })();
-    const { control, handleSubmit, setError, getValues} = _form;
-
+    const { control, handleSubmit, setError, getValues } = _form;
 
     const coerceUndefinedFieldsRef = useRef<Set<string>>(new Set());
 
@@ -408,15 +460,15 @@ export function createTsForm<
     }
     const submitFn = handleSubmit(_submit);
 
-    const isAnyZodObject = (schema: RTFSupportedZodTypes): schema is AnyZodObject => schema._def.typeName === ZodFirstPartyTypeKind.ZodObject;
-    const isZodArray = (schema: RTFSupportedZodTypes): schema is ZodArray<any> => schema._def.typeName === ZodFirstPartyTypeKind.ZodArray;
-
-    type RenderedElement = JSX.Element | JSX.Element[] | RenderedObjectElements | RenderedElement[];
-    type RenderedObjectElements = { [key: string]: RenderedElement };
-
-
-    function renderComponentForSchema<NestedSchemaType extends RTFSupportedZodTypes | ZodEffects<any, any>>(
-      _type: NestedSchemaType, props: PropType<Mapping, NestedSchemaType, PropsMapType> | undefined, key: string, prefixedKey: string, currentValue : any
+    function renderComponentForSchemaDeep<
+      NestedSchemaType extends RTFSupportedZodTypes | ZodEffects<any, any>,
+      K extends keyof z.infer<UnwrapEffects<SchemaType>>
+    >(
+      _type: NestedSchemaType,
+      props: PropType<Mapping, NestedSchemaType, PropsMapType> | undefined,
+      key: K,
+      prefixedKey: string,
+      currentValue: any
     ): RenderedElement {
       const type = unwrapEffects(_type);
       const Component = getComponentForZodType(type, componentMap);
@@ -424,21 +476,37 @@ export function createTsForm<
         if (isAnyZodObject(type)) {
           const shape: Record<string, RTFSupportedZodTypes> = type._def.shape();
           return Object.entries(shape).reduce((accum, [subKey, subType]) => {
-            accum[subKey] = renderComponentForSchema(subType, props && props[subKey] ? (props[subKey] as any) : undefined, subKey, `${prefixedKey}.${subKey}`, currentValue && currentValue[subKey]);
+            accum[subKey] = renderComponentForSchemaDeep(
+              subType,
+              props && props[subKey] ? (props[subKey] as any) : undefined,
+              subKey,
+              `${prefixedKey}.${subKey}`,
+              currentValue && currentValue[subKey]
+            );
             return accum;
-          }, {} as RenderedObjectElements)
+          }, {} as RenderedObjectElements);
         }
         if (isZodArray(type)) {
-          return (currentValue as Array<any>).map((item, index) => {
-            return renderComponentForSchema(type.element, props, key,`${prefixedKey}[${index}]`, item);
-          })
+          return ((currentValue as Array<any> | undefined | null) ?? []).map(
+            (item, index) => {
+              return renderComponentForSchemaDeep(
+                type.element,
+                props,
+                key,
+                `${prefixedKey}[${index}]`,
+                item
+              );
+            }
+          );
         }
         throw new Error(
-          noMatchingSchemaErrorMessage(key, type._def.typeName)
+          noMatchingSchemaErrorMessage(key.toString(), type._def.typeName)
         );
       }
       const meta = getMetaInformationForZodType(type);
 
+      // TODO: we could define a LeafType in the recursive PropType above that only gets applied when we have an actual mapping then we could typeguard to it or cast here
+      // until then this thinks (correctly) that fieldProps might not have beforeElement, afterElement at this level of the prop tree
       const fieldProps = props && props[key] ? (props[key] as any) : {};
 
       const { beforeElement, afterElement } = fieldProps;
@@ -479,27 +547,32 @@ export function createTsForm<
       );
     }
 
-    function renderFields(schema: SchemaType, props: PropType<Mapping, SchemaType, PropsMapType> | undefined) {
+    function renderFields(
+      schema: SchemaType,
+      props: PropType<Mapping, SchemaType, PropsMapType> | undefined
+    ) {
       type SchemaKey = keyof z.infer<UnwrapEffects<SchemaType>>;
       const _schema = unwrapEffects(schema);
       const shape: Record<string, RTFSupportedZodTypes> = _schema._def.shape();
-      return Object.entries(shape).reduce((accum, [key, type]: [SchemaKey, RTFSupportedZodTypes]) => {
-        // we know this is a string but TS thinks it can be number and symbol so just in case stringify
-        const stringKey = key.toString();
-        accum[stringKey] = renderComponentForSchema(type, props, stringKey, stringKey, getValues()[key]);
-        return accum;
-      }, {} as RenderedObjectElements);
+      return Object.entries(shape).reduce(
+        (accum, [key, type]: [SchemaKey, RTFSupportedZodTypes]) => {
+          // we know this is a string but TS thinks it can be number and symbol so just in case stringify
+          const stringKey = key.toString();
+          accum[stringKey] = renderComponentForSchemaDeep(
+            type,
+            props as any,
+            stringKey,
+            stringKey,
+            getValues()[key]
+          );
+          return accum;
+        },
+        {} as RenderedObjectElements
+      ) as RenderedFieldMap<SchemaType>;
     }
 
     const renderedFields = renderFields(schema, props);
-    function getObjectValues(val: RenderedElement): JSX.Element[] {
-        return Array.isArray(val) ?
-          val.flatMap(obj => getObjectValues(obj))
-          : (typeof val === 'object' && val !== null && !React.isValidElement(val)) ?
-            Object.values(val).reduce((accum: JSX.Element[], val) => {return accum.concat(getObjectValues(val as any))}, [] as JSX.Element[])
-            : [val]
-      };
-    const renderedFieldNodes = getObjectValues(renderedFields);
+    const renderedFieldNodes = flattenRenderedElements(renderedFields);
     return (
       <FormProvider {..._form}>
         <ActualFormComponent {...formProps} onSubmit={submitFn}>
@@ -516,4 +589,29 @@ export function createTsForm<
       </FormProvider>
     );
   };
+}
+
+const isAnyZodObject = (schema: RTFSupportedZodTypes): schema is AnyZodObject =>
+  schema._def.typeName === ZodFirstPartyTypeKind.ZodObject;
+const isZodArray = (schema: RTFSupportedZodTypes): schema is ZodArray<any> =>
+  schema._def.typeName === ZodFirstPartyTypeKind.ZodArray;
+
+type RenderedElement =
+  | JSX.Element
+  | JSX.Element[]
+  | RenderedObjectElements
+  | RenderedElement[];
+type RenderedObjectElements = { [key: string]: RenderedElement };
+
+/***
+ * Can be useful in CustomChildComponents to flatten the rendered field map at a given leve
+ */
+export function flattenRenderedElements(val: RenderedElement): JSX.Element[] {
+  return Array.isArray(val)
+    ? val.flatMap((obj) => flattenRenderedElements(obj))
+    : typeof val === "object" && val !== null && !React.isValidElement(val)
+    ? Object.values(val).reduce((accum: JSX.Element[], val) => {
+        return accum.concat(flattenRenderedElements(val as any));
+      }, [] as JSX.Element[])
+    : [val];
 }


### PR DESCRIPTION
closes https://github.com/iway1/react-ts-form/issues/64

@iway1 I'll comment a bit inline but getting this to work turned out to be easy. Getting the types correct was HARD. I had to explicitly limit the depth of the recursion or TS got concerned that it was excessively deep or even infinite. My editor still feels a bit slow with this so maybe you can check this out and try yourself to see how it feels. if it's not feeling good maybe there's a way to optimize. It doesn't feel like TS should have to do that much work to iterate a few levels down an object and map it but 🤷 

Basically this works by recursing iff there's no component found in the mapping for an object or array. The rendered field map passed to CustomChildComponent has the same structure as the data except it has JSX.Element's at the leaves where we found a mapping. Props also map to the structure of the data except that for arrays you can only pass one set of props for the whole array.  I think that's likely the only possible thing because it's not an indexable tuple since the data length varies. 

oh also: i'd love to use a consistent formatter. would you be cool with prettier or something similar? ✅ 