### PR TITLE
feat: support z.nativeEnum

### DIFF
--- a/src/FieldContext.tsx
+++ b/src/FieldContext.tsx
@@ -29,7 +29,7 @@ export const FieldContext = createContext<null | {
   name: string;
   label?: string;
   placeholder?: string;
-  enumValues?: string[];
+  enumValues?: (string | number)[];
   zodType: RTFSupportedZodTypes;
   addToCoerceUndefined: (v: string) => void;
   removeFromCoerceUndefined: (v: string) => void;
@@ -50,7 +50,7 @@ export function FieldContextProvider({
   control: Control<any>;
   label?: string;
   placeholder?: string;
-  enumValues?: string[];
+  enumValues?: (string | number)[];
   children: ReactNode;
   zodType: RTFSupportedZodTypes;
   addToCoerceUndefined: (v: string) => void;

--- a/src/__tests__/createSchemaForm.test.tsx
+++ b/src/__tests__/createSchemaForm.test.tsx
@@ -298,6 +298,46 @@ describe("createSchemaForm", () => {
     expect(screen.queryByText(label)).toBeInTheDocument();
     expect(screen.queryByText(placeholder)).toBeInTheDocument();
   });
+  it("should pass native enum values to the enum field", () => {
+    enum NativeEnumValues {
+      a = "a",
+      b = "b",
+      c3p0 = "c3p0",
+    }
+    const Schema = z.object({
+      enum: z.nativeEnum(NativeEnumValues),
+    });
+
+    render(<TestForm onSubmit={() => {}} schema={Schema} />);
+
+    for (const value of Object.keys(NativeEnumValues)) {
+      expect(screen.queryByText(value)).toBeTruthy();
+    }
+  });
+  it("should pass a label, placeholder and native enum values to a optional enum field with description", () => {
+    enum NativeEnumValues {
+      a = "a",
+      b = "b",
+      c3p0 = "c3p0",
+    }
+    const label = "label";
+    const placeholder = "placeholder";
+    const Schema = z.object({
+      enum: z
+        .nativeEnum(NativeEnumValues)
+        .optional()
+        .describe(`${label}${DESCRIPTION_SEPARATOR_SYMBOL}${placeholder}`),
+    });
+
+    render(<TestForm schema={Schema} onSubmit={() => {}} />);
+
+    for (const value of Object.keys(NativeEnumValues)) {
+      expect(screen.queryByText(value)).toBeTruthy();
+    }
+
+    expect(screen.queryByText(label)).toBeInTheDocument();
+    expect(screen.queryByText(placeholder)).toBeInTheDocument();
+  });
   it("should render with default values if they're passed", () => {
     const defaultValue = "default";
     const Schema = z.object({

--- a/src/__tests__/createSchemaForm.test.tsx
+++ b/src/__tests__/createSchemaForm.test.tsx
@@ -303,6 +303,7 @@ describe("createSchemaForm", () => {
       a = "a",
       b = "b",
       c3p0 = "c3p0",
+      num = 42,
     }
     const Schema = z.object({
       enum: z.nativeEnum(NativeEnumValues),
@@ -310,7 +311,7 @@ describe("createSchemaForm", () => {
 
     render(<TestForm onSubmit={() => {}} schema={Schema} />);
 
-    for (const value of Object.keys(NativeEnumValues)) {
+    for (const value of Object.values(NativeEnumValues)) {
       expect(screen.queryByText(value)).toBeTruthy();
     }
   });
@@ -319,6 +320,7 @@ describe("createSchemaForm", () => {
       a = "a",
       b = "b",
       c3p0 = "c3p0",
+      num = 42,
     }
     const label = "label";
     const placeholder = "placeholder";
@@ -331,7 +333,7 @@ describe("createSchemaForm", () => {
 
     render(<TestForm schema={Schema} onSubmit={() => {}} />);
 
-    for (const value of Object.keys(NativeEnumValues)) {
+    for (const value of Object.values(NativeEnumValues)) {
       expect(screen.queryByText(value)).toBeTruthy();
     }
 

--- a/src/__tests__/utils/testForm.tsx
+++ b/src/__tests__/utils/testForm.tsx
@@ -63,6 +63,11 @@ function CustomTextField(props: {
   );
 }
 export const enumFieldValues = ["a", "b", "c"] as const;
+export enum NativeEnumValues {
+  a = "a",
+  b = "b",
+  c3p0 = "c3p0",
+}
 
 function EnumField({
   enumValues = [],
@@ -92,6 +97,7 @@ const mapping = [
   [z.number(), NumberField] as const,
   [TestCustomFieldSchema, CustomTextField] as const,
   [z.enum(enumFieldValues), EnumField] as const,
+  [z.nativeEnum(NativeEnumValues), EnumField] as const,
 ] as const;
 
 const propsMap = [

--- a/src/__tests__/utils/testForm.tsx
+++ b/src/__tests__/utils/testForm.tsx
@@ -67,6 +67,7 @@ export enum NativeEnumValues {
   a = "a",
   b = "b",
   c3p0 = "c3p0",
+  num = 42,
 }
 
 function EnumField({

--- a/src/getMetaInformationForZodType.ts
+++ b/src/getMetaInformationForZodType.ts
@@ -21,7 +21,7 @@ export function getEnumValues(type: RTFSupportedZodTypes) {
     return type._def.values as readonly string[];
   }
   if (type._def.typeName === z.ZodFirstPartyTypeKind.ZodNativeEnum) {
-    return Object.keys(type._def.values) as readonly string[];
+    return Object.values(type._def.values) as readonly (string | number)[];
   }
   return;
 }

--- a/src/getMetaInformationForZodType.ts
+++ b/src/getMetaInformationForZodType.ts
@@ -17,8 +17,13 @@ export function parseDescription(description?: string) {
 }
 
 export function getEnumValues(type: RTFSupportedZodTypes) {
-  if (!(type._def.typeName === z.ZodFirstPartyTypeKind.ZodEnum)) return;
-  return type._def.values as readonly string[];
+  if (type._def.typeName === z.ZodFirstPartyTypeKind.ZodEnum) {
+    return type._def.values as readonly string[];
+  }
+  if (type._def.typeName === z.ZodFirstPartyTypeKind.ZodNativeEnum) {
+    return Object.keys(type._def.values) as readonly string[];
+  }
+  return;
 }
 
 function isSchemaWithUnwrapMethod(

--- a/src/supportedZodTypes.ts
+++ b/src/supportedZodTypes.ts
@@ -5,6 +5,7 @@ import {
   ZodDate,
   ZodDiscriminatedUnion,
   ZodEnum,
+  ZodNativeEnum,
   ZodMap,
   ZodNullable,
   ZodNumber,
@@ -33,6 +34,7 @@ export type RTFBaseZodType =
   | ZodMap<any>
   | ZodSet<any>
   | ZodEnum<any>
+  | ZodNativeEnum<any>
   | ZodBranded<any, any>
   | ZodEffects<any, any>;
 


### PR DESCRIPTION
Adds support for `z.nativeEnum`, since it's pretty much the same thing as regular `z.enum`.