### PR TITLE
add schema-aware field hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ts-react/form",
-  "version": "1.0.6",
+  "version": "1.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ts-react/form",
-      "version": "1.0.6",
+      "version": "1.4.5",
       "license": "ISC",
       "devDependencies": {
         "@hookform/resolvers": "^2.9.10",
@@ -17,9 +17,12 @@
         "@testing-library/user-event": "^14.4.3",
         "@types/jest": "^29.2.4",
         "@types/react": "^18.0.26",
+        "@types/testing-library__jest-dom": "^5.14.5",
+        "@types/yargs": "^17.0.23",
         "expect-type": "^0.15.0",
         "jest": "^29.3.1",
         "jest-environment-jsdom": "^29.3.1",
+        "prettier": "^2.8.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.41.3",
@@ -1467,9 +1470,9 @@
       "dev": true
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.22",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
-      "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
+      "version": "17.0.23",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.23.tgz",
+      "integrity": "sha512-yuogunc04OnzGQCrfHx+Kk883Q4X0aSwmYZhKjI21m+SVYzjIbrWl8dOOwSv5hf2Um2pdCOXWo9isteZTNXUZQ==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -4615,6 +4618,21 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.6.tgz",
+      "integrity": "sha512-mtuzdiBbHwPEgl7NxWlqOkithPyp4VN93V7VeHVWBF+ad3I5avc0RVDT4oImXQy9H/AqxA2NSQH8pSxHW6FYbQ==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts-react/form",
-  "version": "1.4.5",
+  "version": "1.0.6",
   "description": "Build forms faster!",
   "module": "lib/index.mjs",
   "main": "lib/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts-react/form",
-  "version": "1.0.6",
+  "version": "1.4.5",
   "description": "Build forms faster!",
   "module": "lib/index.mjs",
   "main": "lib/index.cjs",
@@ -35,6 +35,7 @@
     "@types/jest": "^29.2.4",
     "@types/react": "^18.0.26",
     "@types/testing-library__jest-dom": "^5.14.5",
+    "@types/yargs": "^17.0.23",
     "expect-type": "^0.15.0",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ specifiers:
   '@types/jest': ^29.2.4
   '@types/react': ^18.0.26
   '@types/testing-library__jest-dom': ^5.14.5
+  '@types/yargs': ^17.0.23
   expect-type: ^0.15.0
   jest: ^29.3.1
   jest-environment-jsdom: ^29.3.1
@@ -32,6 +33,7 @@ devDependencies:
   '@types/jest': 29.4.0
   '@types/react': 18.0.28
   '@types/testing-library__jest-dom': 5.14.5
+  '@types/yargs': 17.0.23
   expect-type: 0.15.0
   jest: 29.5.0
   jest-environment-jsdom: 29.5.0
@@ -631,7 +633,7 @@ packages:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
       '@types/node': 18.14.6
-      '@types/yargs': 17.0.22
+      '@types/yargs': 17.0.23
       chalk: 4.1.2
     dev: true
 
@@ -920,8 +922,8 @@ packages:
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
     dev: true
 
-  /@types/yargs/17.0.22:
-    resolution: {integrity: sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==}
+  /@types/yargs/17.0.23:
+    resolution: {integrity: sha512-yuogunc04OnzGQCrfHx+Kk883Q4X0aSwmYZhKjI21m+SVYzjIbrWl8dOOwSv5hf2Um2pdCOXWo9isteZTNXUZQ==}
     dependencies:
       '@types/yargs-parser': 21.0.0
     dev: true

--- a/src/FieldContext.tsx
+++ b/src/FieldContext.tsx
@@ -15,12 +15,14 @@ import {
   RTFSupportedZodFirstPartyTypeKindMap,
   isTypeOf,
   isZodArray,
+  isZodDefaultDef,
 } from "./isZodTypeEqual";
 
 import {
   PickPrimitiveObjectProperties,
   pickPrimitiveObjectProperties,
 } from "./utilities";
+import { ZodDefaultDef } from "zod";
 
 export const FieldContext = createContext<null | {
   control: Control<any>;
@@ -260,15 +262,28 @@ function getFieldInfo<
 >(zodType: TZodType) {
   const { type, _rtf_id } = unwrap(zodType);
 
+  function getDefaultValue() {
+    const def = zodType._def;
+    if (isZodDefaultDef(def)) {
+      const defaultValue = (def as ZodDefaultDef<TZodType>).defaultValue();
+      return defaultValue;
+    }
+    return undefined;
+  }
+
   return {
     type: type as TUnwrapZodType,
     zodType,
     uniqueId: _rtf_id ?? undefined,
     isOptional: zodType.isOptional(),
     isNullable: zodType.isNullable(),
+    defaultValue: getDefaultValue(),
   };
 }
 
+/**
+ * @internal
+ */
 export function internal_useFieldInfo<
   TZodType extends RTFSupportedZodTypes = RTFSupportedZodTypes,
   TUnwrappedZodType extends UnwrapZodType<TZodType> = UnwrapZodType<TZodType>

--- a/src/FieldContext.tsx
+++ b/src/FieldContext.tsx
@@ -8,6 +8,18 @@ import {
 } from "react-hook-form";
 import { printUseEnumWarning } from "./logging";
 import { errorFromRhfErrorObject } from "./zodObjectErrors";
+import { RTFSupportedZodTypes } from "./supportedZodTypes";
+import { UnwrapZodType, unwrap } from "./unwrap";
+import {
+  RTFSupportedZodFirstPartyTypeKind,
+  RTFSupportedZodFirstPartyTypeKindMap,
+  isTypeOf,
+} from "./isZodTypeEqual";
+
+import {
+  PickPrimitiveObjectProperties,
+  pickPrimitiveObjectProperties,
+} from "./utilities";
 
 export const FieldContext = createContext<null | {
   control: Control<any>;
@@ -15,6 +27,7 @@ export const FieldContext = createContext<null | {
   label?: string;
   placeholder?: string;
   enumValues?: string[];
+  zodType: RTFSupportedZodTypes;
   addToCoerceUndefined: (v: string) => void;
   removeFromCoerceUndefined: (v: string) => void;
 }>(null);
@@ -26,6 +39,7 @@ export function FieldContextProvider({
   label,
   placeholder,
   enumValues,
+  zodType,
   addToCoerceUndefined,
   removeFromCoerceUndefined,
 }: {
@@ -35,6 +49,7 @@ export function FieldContextProvider({
   placeholder?: string;
   enumValues?: string[];
   children: ReactNode;
+  zodType: RTFSupportedZodTypes;
   addToCoerceUndefined: (v: string) => void;
   removeFromCoerceUndefined: (v: string) => void;
 }) {
@@ -46,6 +61,7 @@ export function FieldContextProvider({
         label,
         placeholder,
         enumValues,
+        zodType,
         addToCoerceUndefined,
         removeFromCoerceUndefined,
       }}
@@ -201,6 +217,13 @@ export function enumValuesNotPassedError() {
   return `Enum values not passed. Any component that calls useEnumValues should be rendered from an '.enum()' zod field.`;
 }
 
+export function fieldSchemaMismatchHookError(
+  hookName: string,
+  expectedType: string
+) {
+  return `Make sure that ${hookName} hook it is being called inside of a custom component which matches the type '${expectedType}'`;
+}
+
 /**
  * Gets an enum fields values. Throws an error if there are no enum values found (IE you mapped a z.string() to a component
  * that calls this hook).
@@ -228,3 +251,126 @@ export function useEnumValues() {
   if (!enumValues) throw new Error(enumValuesNotPassedError());
   return enumValues;
 }
+
+/**
+ * Returns the Zod type for a field.
+ *
+ * @returns  The Zod type for the field.
+ */
+export function useFieldZodType() {
+  const { zodType } = useContextProt("useFieldZodType");
+  return zodType;
+}
+
+function getFieldInfo<
+  TZodType extends RTFSupportedZodTypes,
+  TUnwrapZodType extends UnwrapZodType<TZodType> = UnwrapZodType<TZodType>
+>(zodType: TZodType) {
+  const { type, _rtf_id } = unwrap(zodType);
+
+  return {
+    type: type as TUnwrapZodType,
+    zodType,
+    uniqueId: _rtf_id ?? undefined,
+    isOptional: zodType.isOptional(),
+    isNullable: zodType.isNullable(),
+  };
+}
+
+export function internal_useFieldInfo<
+  TZodType extends RTFSupportedZodTypes = RTFSupportedZodTypes,
+  TUnwrappedZodType extends UnwrapZodType<TZodType> = UnwrapZodType<TZodType>
+>(hookName: string) {
+  const { zodType, label, placeholder } = useContextProt(hookName);
+
+  const fieldInfo = getFieldInfo<TZodType, TUnwrappedZodType>(
+    zodType as TZodType
+  );
+
+  return { ...fieldInfo, label, placeholder };
+}
+
+/**
+ * Returns schema-related information for a field
+ *
+ * @returns The Zod type for the field.
+ */
+export function useFieldInfo() {
+  return internal_useFieldInfo("useFieldInfo");
+}
+
+export function usePickZodFields<
+  TZodKindName extends RTFSupportedZodFirstPartyTypeKind,
+  TZodType extends RTFSupportedZodFirstPartyTypeKindMap[TZodKindName] = RTFSupportedZodFirstPartyTypeKindMap[TZodKindName],
+  TUnwrappedZodType extends UnwrapZodType<TZodType> = UnwrapZodType<TZodType>,
+  TPick extends Partial<
+    PickPrimitiveObjectProperties<TUnwrappedZodType, true>
+  > = Partial<PickPrimitiveObjectProperties<TUnwrappedZodType, true>>
+>(zodKindName: TZodKindName, pick: TPick, hookName: string) {
+  const fieldInfo = internal_useFieldInfo<TZodType, TUnwrappedZodType>(
+    hookName
+  );
+  const { type } = fieldInfo;
+
+  if (!isTypeOf(type, zodKindName)) {
+    throw new Error(fieldSchemaMismatchHookError(hookName, zodKindName));
+  }
+
+  return {
+    ...pickPrimitiveObjectProperties<TUnwrappedZodType, TPick>(type, pick),
+    ...fieldInfo,
+  };
+}
+
+/**
+ * Returns schema-related information for a ZodString field
+ *
+ * @example
+ * ```tsx
+ * const CustomComponent = () => {
+ *   const { minLength, maxLength, uniqueId } = useStringFieldInfo();
+ *
+ *   return <input minLength={minLength} maxLength={maxLength} />;
+ * };
+ * ```
+ * @returns Information for a ZodString field
+ */
+export function useStringFieldInfo() {
+  return usePickZodFields(
+    "ZodString",
+    {
+      isCUID: true,
+      isCUID2: true,
+      isDatetime: true,
+      isEmail: true,
+      isEmoji: true,
+      isIP: true,
+      isULID: true,
+      isURL: true,
+      isUUID: true,
+      maxLength: true,
+      minLength: true,
+    },
+    "useStringFieldInfo"
+  );
+}
+
+/**
+ * Returns schema-related information for a ZodNumber field
+ *
+ * @returns data for a ZodNumber field
+ */
+export function useNumberFieldInfo() {
+  return usePickZodFields(
+    "ZodNumber",
+    {
+      isFinite: true,
+      isInt: true,
+      maxValue: true,
+      minValue: true,
+    },
+    "useNumberFieldInfo"
+  );
+}
+
+const {} = useNumberFieldInfo;

--- a/src/FieldContext.tsx
+++ b/src/FieldContext.tsx
@@ -221,7 +221,7 @@ export function fieldSchemaMismatchHookError(
   hookName: string,
   expectedType: string
 ) {
-  return `Make sure that ${hookName} hook it is being called inside of a custom component which matches the type '${expectedType}'`;
+  return `Make sure that the '${hookName}' hook is being called inside of a custom form component which matches the type '${expectedType}'`;
 }
 
 /**
@@ -299,6 +299,10 @@ export function useFieldInfo() {
   return internal_useFieldInfo("useFieldInfo");
 }
 
+/**
+ * The zod type objects contain virtual properties which requires us to
+ * manually pick the properties we'd like inorder to get their values.
+ */
 export function usePickZodFields<
   TZodKindName extends RTFSupportedZodFirstPartyTypeKind,
   TZodType extends RTFSupportedZodFirstPartyTypeKindMap[TZodKindName] = RTFSupportedZodFirstPartyTypeKindMap[TZodKindName],
@@ -372,5 +376,3 @@ export function useNumberFieldInfo() {
     "useNumberFieldInfo"
   );
 }
-
-const {} = useNumberFieldInfo;

--- a/src/FieldContext.tsx
+++ b/src/FieldContext.tsx
@@ -252,16 +252,6 @@ export function useEnumValues() {
   return enumValues;
 }
 
-/**
- * Returns the Zod type for a field.
- *
- * @returns  The Zod type for the field.
- */
-export function useFieldZodType() {
-  const { zodType } = useContextProt("useFieldZodType");
-  return zodType;
-}
-
 function getFieldInfo<
   TZodType extends RTFSupportedZodTypes,
   TUnwrapZodType extends UnwrapZodType<TZodType> = UnwrapZodType<TZodType>

--- a/src/__tests__/createSchemaForm.test.tsx
+++ b/src/__tests__/createSchemaForm.test.tsx
@@ -1304,10 +1304,10 @@ describe("createSchemaForm", () => {
       UNIQUE_STRING_SCHEMA_ID
     );
 
-    const decsription = `${label}${DESCRIPTION_SEPARATOR_SYMBOL}${placeholder}`;
+    const description = `${label}${DESCRIPTION_SEPARATOR_SYMBOL}${placeholder}`;
 
     const schema = z.object({
-      name: StringSchema.describe(decsription),
+      name: StringSchema.describe(description),
     });
 
     const mapping = [[StringSchema, CustomTextField]] as const;
@@ -1337,5 +1337,3 @@ describe("createSchemaForm", () => {
     expect(screen.getByText(UNIQUE_STRING_SCHEMA_ID)).toBeInTheDocument();
   });
 });
-
-console.log(useStringFieldInfo);

--- a/src/__tests__/createSchemaForm.test.tsx
+++ b/src/__tests__/createSchemaForm.test.tsx
@@ -1236,7 +1236,19 @@ describe("createSchemaForm", () => {
       return <input />;
     }
 
+    const defaultEmail = "john@example.com";
+
+    const DefaultTextField = () => {
+      // @ts-expect-error
+      const { defaultValue, type, zodType } = useFieldInfo();
+
+      expect(defaultValue).toBe(defaultEmail);
+
+      return <input />;
+    };
+
     const schema = z.object({
+      email: z.string().default(defaultEmail),
       name: RequiredTextFieldSchema.describe(description("requiredTextField")),
       nickName: OptionalTextFieldSchema.describe(
         description("optionalTextField")
@@ -1244,6 +1256,7 @@ describe("createSchemaForm", () => {
     });
 
     const mapping = [
+      [z.string(), DefaultTextField],
       [RequiredTextFieldSchema, RequiredTextField],
       [OptionalTextFieldSchema, OptionalTextField],
     ] as const;

--- a/src/__tests__/createSchemaForm.test.tsx
+++ b/src/__tests__/createSchemaForm.test.tsx
@@ -25,13 +25,11 @@ import {
   useEnumValues,
   useReqDescription,
   useTsController,
-  useFieldZodType,
   useStringFieldInfo,
   useFieldInfo,
 } from "../FieldContext";
 import { expectTypeOf } from "expect-type";
 import { createUniqueFieldSchema } from "../createFieldSchema";
-import { unwrap } from "../unwrap";
 
 const testIds = {
   textField: "_text-field",
@@ -1185,45 +1183,7 @@ describe("createSchemaForm", () => {
     expect(screen.queryByText("one")).toBeInTheDocument();
     expect(screen.queryByText("two")).toBeInTheDocument();
   });
-  it("should be possible to get the Zod type for a field using `useFieldZodType`", () => {
-    const stringComponentId = "custom-string";
-    const numberComponentId = "custom-number";
-
-    const StringSchema = createUniqueFieldSchema(z.string(), stringComponentId);
-    const NumberSchema = createUniqueFieldSchema(z.number(), numberComponentId);
-
-    const schema = z.object({
-      name: StringSchema.optional(),
-      age: NumberSchema,
-    });
-
-    const mapping = [
-      [StringSchema, TextField],
-      [z.string(), TextField],
-      [NumberSchema, NumberField],
-    ] as const;
-
-    const Form = createTsForm(mapping);
-
-    function TextField() {
-      const zodType = useFieldZodType();
-
-      expect(unwrap(zodType)._rtf_id).toBe(stringComponentId);
-
-      return <input />;
-    }
-
-    function NumberField() {
-      const zodType = useFieldZodType();
-
-      expect(unwrap(zodType)._rtf_id).toBe(numberComponentId);
-
-      return <input />;
-    }
-
-    render(<Form schema={schema} onSubmit={() => {}} />);
-  });
-  it.only("should be possible to get ZodAny information using `useFieldInfo`", () => {
+  it("should be possible to get ZodAny information using `useFieldInfo`", () => {
     const testData = {
       requiredTextField: {
         label: "required-label",

--- a/src/createSchemaForm.tsx
+++ b/src/createSchemaForm.tsx
@@ -397,8 +397,6 @@ export function createTsForm<
 
         const { beforeElement, afterElement } = fieldProps;
 
-        console.log("PROPS MAP", propsMap);
-
         const mergedProps = {
           ...(propsMap.name && { [propsMap.name]: key }),
           ...(propsMap.control && { [propsMap.control]: control }),

--- a/src/createSchemaForm.tsx
+++ b/src/createSchemaForm.tsx
@@ -397,6 +397,8 @@ export function createTsForm<
 
         const { beforeElement, afterElement } = fieldProps;
 
+        console.log("PROPS MAP", propsMap);
+
         const mergedProps = {
           ...(propsMap.name && { [propsMap.name]: key }),
           ...(propsMap.control && { [propsMap.control]: control }),
@@ -420,6 +422,7 @@ export function createTsForm<
               control={control}
               name={stringKey}
               label={ctxLabel}
+              zodType={type}
               placeholder={ctxPlaceholder}
               enumValues={meta.enumValues as string[] | undefined}
               addToCoerceUndefined={submitter.addToCoerceUndefined}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,5 +5,8 @@ export {
   useReqDescription,
   useEnumValues,
   useTsController,
+  useFieldInfo,
+  useStringFieldInfo,
+  useNumberFieldInfo
 } from "./FieldContext";
 export type { RTFSupportedZodTypes } from "./supportedZodTypes";

--- a/src/isZodTypeEqual.tsx
+++ b/src/isZodTypeEqual.tsx
@@ -1,4 +1,13 @@
-import { ZodFirstPartyTypeKind } from "zod";
+import {
+  AnyZodObject,
+  ZodArray,
+  ZodBoolean,
+  ZodDate,
+  ZodFirstPartyTypeKind,
+  ZodNumber,
+  ZodString,
+  z,
+} from "zod";
 import { RTFSupportedZodTypes } from "./supportedZodTypes";
 import { unwrap } from "./unwrap";
 
@@ -19,6 +28,8 @@ export function isZodTypeEqual(
 
   if (a._def.typeName !== b._def.typeName) return false;
 
+  // array
+
   if (
     a._def.typeName === ZodFirstPartyTypeKind.ZodArray &&
     b._def.typeName === ZodFirstPartyTypeKind.ZodArray
@@ -27,6 +38,8 @@ export function isZodTypeEqual(
     return false;
   }
 
+  // set
+
   if (
     a._def.typeName === ZodFirstPartyTypeKind.ZodSet &&
     b._def.typeName === ZodFirstPartyTypeKind.ZodSet
@@ -34,6 +47,8 @@ export function isZodTypeEqual(
     if (isZodTypeEqual(a._def.valueType, b._def.valueType)) return true;
     return false;
   }
+
+  // map
 
   if (
     a._def.typeName === ZodFirstPartyTypeKind.ZodMap &&
@@ -103,3 +118,57 @@ export function isZodTypeEqual(
   }
   return true;
 }
+
+// Guards
+
+export function isZodString(
+  zodType: RTFSupportedZodTypes
+): zodType is ZodString {
+  return isTypeOf(zodType, "ZodString");
+}
+
+export function isZodNumber(
+  zodType: RTFSupportedZodTypes
+): zodType is ZodNumber {
+  return isTypeOf(zodType, "ZodNumber");
+}
+
+export function isZodBoolean(
+  zodType: RTFSupportedZodTypes
+): zodType is ZodBoolean {
+  return isTypeOf(zodType, "ZodBoolean");
+}
+
+export function isZodArray(
+  zodType: RTFSupportedZodTypes
+): zodType is ZodArray<any> {
+  return isTypeOf(zodType, "ZodArray");
+}
+
+export function isZodObject(
+  zodType: RTFSupportedZodTypes
+): zodType is AnyZodObject {
+  return isTypeOf(zodType, "ZodObject");
+}
+
+export function isZodDate(zodType: RTFSupportedZodTypes): zodType is ZodDate {
+  return isTypeOf(zodType, "ZodDate");
+}
+
+export function isTypeOf(zodType: RTFSupportedZodTypes, type: ZodKindName) {
+  return zodType._def.typeName === ZodFirstPartyTypeKind[type];
+}
+
+type ZodKindName = keyof typeof z.ZodFirstPartyTypeKind;
+
+export type ZodKindNameToType<K extends keyof typeof z.ZodFirstPartyTypeKind> =
+  InstanceType<(typeof z)[K]>;
+
+export type RTFSupportedZodFirstPartyTypeKindMap = {
+  [K in ZodKindName as ZodKindNameToType<K> extends RTFSupportedZodTypes
+    ? K
+    : never]: ZodKindNameToType<K>;
+};
+
+export type RTFSupportedZodFirstPartyTypeKind =
+  keyof RTFSupportedZodFirstPartyTypeKindMap;

--- a/src/isZodTypeEqual.tsx
+++ b/src/isZodTypeEqual.tsx
@@ -3,6 +3,7 @@ import {
   ZodArray,
   ZodBoolean,
   ZodDate,
+  ZodDefaultDef,
   ZodFirstPartyTypeKind,
   ZodNumber,
   ZodString,
@@ -149,6 +150,15 @@ export function isZodObject(
   zodType: RTFSupportedZodTypes
 ): zodType is AnyZodObject {
   return isTypeOf(zodType, "ZodObject");
+}
+
+export function isZodDefaultDef(zodDef: unknown): zodDef is ZodDefaultDef {
+  return Boolean(
+    zodDef &&
+      typeof zodDef === "object" &&
+      "defaultValue" in zodDef &&
+      typeof zodDef.defaultValue === "function"
+  );
 }
 
 export function isZodDate(zodType: RTFSupportedZodTypes): zodType is ZodDate {

--- a/src/typeUtilities.ts
+++ b/src/typeUtilities.ts
@@ -101,3 +101,24 @@ export type IndexOf<V extends readonly any[], T> = {
       : never
     : never;
 }[keyof Indexes<V>];
+
+/**
+ * @internal
+ */
+export type ExpandRecursively<T> = T extends object
+  ? T extends infer O
+    ? { [K in keyof O]: ExpandRecursively<O[K]> }
+    : never
+  : T;
+
+/**
+ * @internal
+ */
+export type NullToUndefined<T> = T extends null ? undefined : T;
+
+/**
+ * @internal
+ */
+export type RemoveNull<T> = ExpandRecursively<{
+  [K in keyof T]: NullToUndefined<T[K]>;
+}>;

--- a/src/unwrap.tsx
+++ b/src/unwrap.tsx
@@ -18,10 +18,14 @@ const unwrappable = new Set<z.ZodFirstPartyTypeKind>([
   z.ZodFirstPartyTypeKind.ZodDefault,
 ]);
 
-export function unwrap(type: RTFSupportedZodTypes): {
+export type UnwrappedRTFSupportedZodTypes = {
   type: RTFSupportedZodTypes;
   [HIDDEN_ID_PROPERTY]: string | null;
-} {
+};
+
+export function unwrap(
+  type: RTFSupportedZodTypes
+): UnwrappedRTFSupportedZodTypes {
   // Realized zod has a built in "unwrap()" function after writing this.
   // Not sure if it's super necessary.
   let r = type;

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,0 +1,50 @@
+import { Primitive as ZodPrimitive } from "zod";
+import { RemoveNull } from "./typeUtilities";
+
+type InternalKey = `_${string}`;
+
+type Primitive = Exclude<ZodPrimitive, symbol>;
+
+export type PickPrimitiveObjectProperties<
+  T,
+  TValue extends false | unknown = false
+> = {
+  [K in keyof T as T[K] extends Exclude<Primitive, symbol>
+    ? Exclude<K, InternalKey>
+    : never]: TValue extends false ? T[K] : TValue;
+};
+
+type PickResult<T extends object, P extends object> = Pick<
+  T,
+  Extract<keyof P, keyof T>
+>;
+
+/**
+ * Picks only properties with primitive values
+ * Picks only properties with primitive values from an object and returns a new object with those properties.
+ *
+ * @returns A new object containing only the properties with primitive values.
+ *
+ */
+export function pickPrimitiveObjectProperties<
+  T extends object,
+  TPick extends Partial<PickPrimitiveObjectProperties<T, true>>,
+  TObj extends PickPrimitiveObjectProperties<T> = PickPrimitiveObjectProperties<T>,
+  TResult extends RemoveNull<PickResult<TObj, TPick>> = RemoveNull<
+    PickResult<TObj, TPick>
+  >
+>(obj: T, pick: TPick): TResult {
+  return Object.entries(pick).reduce((result, [key]) => {
+    const value = obj[key as keyof typeof obj];
+    if (
+      typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean" ||
+      typeof value === "bigint" ||
+      value === undefined
+    ) {
+      (result as any)[key] = value;
+    }
+    return result;
+  }, {} as Pick<TObj, Extract<keyof TPick, keyof TObj>>) as TResult;
+}

--- a/www/docs/docs/usage/field-schema-info.md
+++ b/www/docs/docs/usage/field-schema-info.md
@@ -1,0 +1,76 @@
+# Access Schema Data
+
+From a custom form component, we're able to access field schema information through a set of hooks.<br/>
+This allows components to access information about the type and validation rules of the corresponding form field.
+
+
+## `useFieldInfo`
+
+Returns schema-related information for any field
+
+```tsx
+import { useFieldInfo } from "./FieldContext";
+
+const MyCustomField = () => {
+  const { label, placeholder, isOptional, zodType } = useFieldInfo();
+  return (
+    <div>
+      {label}
+      <input placeholder={placeholder} required={!isOptional} />
+    </div>
+  );
+};
+```
+
+
+## `useStringFieldInfo` 
+
+Returns schema-related information for a ZodString field
+
+
+```tsx
+import { useStringFieldInfo } from "./FieldContext";
+
+const MyStringCustomField = () => {
+    
+  const { label, placeholder, isOptional, minLength, maxLength, zodType } =
+    useStringFieldInfo();
+
+  return (
+    <div>
+      {label}
+      <input
+        placeholder={placeholder}
+        required={!isOptional}
+        minLength={minLength}
+        maxLength={maxLength}
+      />
+    </div>
+  );
+};
+```
+
+## `useNumberFieldInfo` 
+
+Returns schema-related information for a ZodNumber field
+
+```tsx
+import { useNumberFieldInfo } from "./FieldContext";
+
+const MyNumberCustomField = () => {
+  const { label, placeholder, isOptional, minValue, maxValue, isInt, zodType } =
+    useNumberFieldInfo();
+  return (
+    <div>
+      {label}
+      <input
+        placeholder={placeholder}
+        required={!isOptional}
+        min={minValue}
+        max={maxValue}
+        step={isInt ? undefined : 0.1}
+      />
+    </div>
+  );
+};
+```

--- a/www/docs/docs/usage/field-schema-info.md
+++ b/www/docs/docs/usage/field-schema-info.md
@@ -9,7 +9,7 @@ This allows components to access information about the type and validation rules
 Returns schema-related information for any field
 
 ```tsx
-import { useFieldInfo } from "./FieldContext";
+import { useFieldInfo } from "@ts-react/form";
 
 const MyCustomField = () => {
   const { label, placeholder, isOptional, zodType } = useFieldInfo();
@@ -29,7 +29,7 @@ Returns schema-related information for a ZodString field
 
 
 ```tsx
-import { useStringFieldInfo } from "./FieldContext";
+import { useStringFieldInfo } from "@ts-react/form";
 
 const MyStringCustomField = () => {
     
@@ -55,7 +55,7 @@ const MyStringCustomField = () => {
 Returns schema-related information for a ZodNumber field
 
 ```tsx
-import { useNumberFieldInfo } from "./FieldContext";
+import { useNumberFieldInfo } from "@ts-react/form";
 
 const MyNumberCustomField = () => {
   const { label, placeholder, isOptional, minValue, maxValue, isInt, zodType } =

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -19,6 +19,8 @@
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "2.3.1",
+        "@docusaurus/theme-common": "^2.3.1",
+        "@docusaurus/types": "^2.3.1",
         "@tsconfig/docusaurus": "^1.0.5",
         "autoprefixer": "^10.4.13",
         "docusaurus-tailwindcss": "^0.1.0",
@@ -29,6 +31,9 @@
       },
       "engines": {
         "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "@docusaurus/theme-common": "^2.1.0"
       }
     },
     "node_modules/@algolia/autocomplete-core": {

--- a/www/sidebars.js
+++ b/www/sidebars.js
@@ -30,6 +30,7 @@ const sidebars = {
         { type: "doc", id: "docs/usage/default-values" },
         { type: "doc", id: "docs/usage/form-state" },
         { type: "doc", id: "docs/usage/labels-placeholders" },
+        { type: "doc", id: "docs/usage/field-schema-info" },
       ],
     },
     {


### PR DESCRIPTION
Introduces hooks which allow access to a field's schema data from within a custom form component via hooks. 


**Use cases:**

- Render an `*` based on whether or not the field `isOptional`
- Get validation data like `maxLength` `minLength` defined originally  in the schema 
- Access a field's ZodType 

This pull request adds capabilities referenced in #71 

## `useFieldInfo`

Returns schema-related information for any field.

Additionally, this hook includes `label` and `placeholder` which is currently gotten via the `useDescription` hook. 

```tsx
import { useFieldInfo } from "@ts-form/react";

const MyCustomField = () => {
  const { label, placeholder, isOptional, zodType } = useFieldInfo();
  return (
    <div>
      {label}
      <input placeholder={placeholder} required={!isOptional} />
    </div>
  );
};
```


## `useStringFieldInfo` 

Returns schema-related information for a ZodString field


```tsx
import { useStringFieldInfo } from "@ts-form/react";

const MyStringCustomField = () => {
    
  const { label, placeholder, isOptional, minLength, maxLength, zodType } =
    useStringFieldInfo();

  return (
    <div>
      {label}
      <input
        placeholder={placeholder}
        required={!isOptional}
        minLength={minLength}
        maxLength={maxLength}
      />
    </div>
  );
};
```

## `useNumberFieldInfo` 

Returns schema-related information for a ZodNumber field

```tsx
import { useNumberFieldInfo } from "@ts-form/react";

const MyNumberCustomField = () => {
  const { label, placeholder, isOptional, minValue, maxValue, isInt, zodType } =
    useNumberFieldInfo();
  return (
    <div>
      {label}
      <input
        placeholder={placeholder}
        required={!isOptional}
        min={minValue}
        max={maxValue}
        step={isInt ? undefined : 0.1}
      />
    </div>
  );
};
```

