### PR TITLE
Fix recursive form generation typescript perf

### DIFF
--- a/src/__tests__/createSchemaForm.test.tsx
+++ b/src/__tests__/createSchemaForm.test.tsx
@@ -172,6 +172,7 @@ describe("createSchemaForm", () => {
     expect(() =>
       render(
         <Form
+          onSubmit={() => {}}
           schema={Schema}
           props={{
             //@ts-ignore
@@ -1353,5 +1354,157 @@ describe("createSchemaForm", () => {
     expect(
       screen.queryByText(testData.arrayTextField.label)
     ).toBeInTheDocument();
+  });
+  it("should render the correct components for a nested object schema if unmaped", async () => {
+    const NumberSchema = createUniqueFieldSchema(z.number(), "number");
+    const mockOnSubmit = jest.fn();
+
+    function TextField({}: { b: "1" }) {
+      const { error } = useTsController<string>();
+      return (
+        <>
+          <div>text</div>
+          <div data-testid="error">{error?.errorMessage}</div>
+        </>
+      );
+    }
+
+    function NumberField({}: { a: 1 }) {
+      return <div>number</div>;
+    }
+
+    function BooleanField({}: { c: boolean }) {
+      return <div>boolean</div>;
+    }
+
+    const objectSchema = z.object({
+      text: z.string(),
+      age: NumberSchema,
+    });
+    const objectSchema2 = z.object({
+      bool: z.boolean(),
+    });
+
+    const mapping = [
+      [z.string(), TextField],
+      [NumberSchema, NumberField],
+      [z.boolean(), BooleanField],
+      [objectSchema2, BooleanField],
+    ] as const;
+
+    const Form = createTsForm(mapping);
+
+    const schema = z.object({
+      nestedField: objectSchema,
+      nestedField2: objectSchema2,
+    });
+    const defaultValues = {
+      nestedField: { text: "name", age: 9 },
+      nestedField2: { bool: true },
+    };
+    // TODO: test validation
+    render(
+      <Form
+        schema={schema}
+        onSubmit={mockOnSubmit}
+        defaultValues={defaultValues}
+        props={{
+          nestedField2: { c: true },
+          nestedField: { text: { b: "1" }, age: { a: 1 } },
+        }}
+        renderAfter={() => <button type="submit">submit</button>}
+      />
+    );
+    const button = screen.getByText("submit");
+    await userEvent.click(button);
+
+    const textNodes = screen.queryByText("text");
+    expect(textNodes).toBeInTheDocument();
+    const numberNodes = screen.queryByText("number");
+    expect(numberNodes).toBeInTheDocument();
+    expect(screen.queryByTestId("error")).toHaveTextContent("");
+    expect(mockOnSubmit).toHaveBeenCalledWith(defaultValues);
+  });
+  it("should render two copies of an object schema if in an unmapped array schema", async () => {
+    const NumberSchema = createUniqueFieldSchema(z.number(), "number");
+    const mockOnSubmit = jest.fn();
+
+    function TextField({}: { a?: 1 }) {
+      return <div>text</div>;
+    }
+
+    function NumberField() {
+      return <div>number</div>;
+    }
+
+    function ObjectField({ objProp }: { objProp: 2 }) {
+      return <div>{objProp}</div>;
+    }
+
+    const otherObjSchema = z.object({
+      text: z.string().optional(),
+    });
+    const mapping = [
+      [z.string(), TextField],
+      [NumberSchema, NumberField],
+      [otherObjSchema, ObjectField],
+    ] as const;
+
+    const Form = createTsForm(mapping);
+
+    const schema = z.object({
+      arrayField: z
+        .object({
+          text: z.string(),
+          age: NumberSchema,
+          otherObj: otherObjSchema.optional(),
+        })
+        .array(),
+    });
+    const defaultValues = {
+      arrayField: [
+        { text: "name", age: 9 },
+        { text: "name2", age: 10 },
+      ],
+    };
+    render(
+      <Form
+        schema={schema}
+        onSubmit={mockOnSubmit}
+        defaultValues={defaultValues}
+        // otherObj tests that nonrecursive mapping still works at the last level of the recursion depth
+        props={{ arrayField: { text: { a: 1 }, otherObj: { objProp: 2 } } }}
+        renderAfter={() => {
+          return <button type="submit">submit</button>;
+        }}
+      >
+        {(renderedFields) => {
+          return (
+            <>
+              {renderedFields.arrayField.map(
+                ({ text, age }: any, i: number) => (
+                  <React.Fragment key={i}>
+                    {text}
+                    {age}
+                  </React.Fragment>
+                )
+              )}
+            </>
+          );
+        }}
+      </Form>
+    );
+
+    const textNodes = screen.queryAllByText("text");
+    textNodes.forEach((node) => expect(node).toBeInTheDocument());
+    expect(textNodes).toHaveLength(2);
+
+    const numberNodes = screen.queryAllByText("number");
+    numberNodes.forEach((node) => expect(node).toBeInTheDocument());
+    expect(numberNodes).toHaveLength(2);
+
+    const button = screen.getByText("submit");
+    await userEvent.click(button);
+    expect(mockOnSubmit).toHaveBeenCalledWith(defaultValues);
   });
 });


### PR DESCRIPTION
Reverted the revert. Got it working again and figured out the few reasons for the typescript perf problems. 

Closes https://github.com/iway1/react-ts-form/issues/64 (again)

1. RenderedFieldMap also needs the recursion level limit (this was the big one)
2. All the types used by exported types need to be exported as well or the compiler tries to inline them resulting in `The inferred type of this node exceeds the maximum length the compiler will serialize. An explicit type annotation is needed.`
3. Don't force TS to infer the return type of createTSform. make it explicit since we can.

I tested editor perf locally and I found that depth 3 is the farthest TS will go without becoming extremely slow so I made that the maximum possible in the Prev tuple. 3 is also quite a bit slower than 2. I can feel a very slight difference between 2 and 1 but both are reasonable. I left it at depth 1 because this still allows arrays of objects, and one level of object nesting which covers our main use case, but we could probably bump it to 2 safely if we end up wanting it.

Hopefully this solves it this time! Let me know what you think! @iway1 