### PR TITLE
Lower required version of React in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   ],
   "peerDependencies": {
     "@hookform/resolvers": "^2.8.0",
-    "react": "^18.0.0",
+    "react": "^16.8.0 || ^17 || ^18",
     "react-hook-form": "^7.39.0",
     "zod": "^3.19.0"
   }


### PR DESCRIPTION
Lowers required version of React in peerDependencies to match the range currently supported by [`react-hook-form` (`"^16.8.0 || ^17 || ^18"`)](https://github.com/react-hook-form/react-hook-form/blob/master/package.json#L122)

Closes #93 