### PR TITLE
make prop type ignore array cardinality

### DIFF
--- a/src/unwrap.tsx
+++ b/src/unwrap.tsx
@@ -1,5 +1,6 @@
 import {
   z,
+  ZodArray,
   ZodEnum,
   ZodFirstPartyTypeKind,
   ZodNullable,
@@ -78,12 +79,18 @@ export function unwrapEffects(effects: RTFSupportedZodTypes) {
  */
 export type UnwrapZodType<T extends RTFSupportedZodTypes> =
   T extends ZodOptional<any>
-    ? EnumAsAnyEnum<T["_def"]["innerType"]>
+    ? GenericizeLeafTypes<T["_def"]["innerType"]>
     : T extends ZodNullable<any>
     ? T["_def"]["innerType"] extends ZodOptional<any>
-      ? EnumAsAnyEnum<T["_def"]["innerType"]["_def"]["innerType"]>
-      : EnumAsAnyEnum<T["_def"]["innerType"]>
-    : EnumAsAnyEnum<T>;
+      ? GenericizeLeafTypes<T["_def"]["innerType"]["_def"]["innerType"]>
+      : GenericizeLeafTypes<T["_def"]["innerType"]>
+    : GenericizeLeafTypes<T>;
+
+export type GenericizeLeafTypes<T extends RTFSupportedZodTypes> =
+  ArrayAsLengthAgnostic<EnumAsAnyEnum<T>>;
+
+export type ArrayAsLengthAgnostic<T extends RTFSupportedZodTypes> =
+  T extends ZodArray<any, any> ? ZodArray<T["element"]> : T;
 
 export type EnumAsAnyEnum<T extends RTFSupportedZodTypes> =
   T extends ZodEnum<any> ? ZodEnum<any> : T;


### PR DESCRIPTION
@iway1 Our code finds a mapping based on array type ignoring cardinality but the prop types map only if the mapping includes the exact cardinality. This makes the Unwrap unwrap array cardinality as well so the types match the code behavior. I added a test that only compiles with this unwrap change and also tested to make sure the code actually renders this mapping regardless of cardinality as well.

Alternatively we could make the code match the types and render a different mapping for different cardinality arrays but i think this is likely preferred. Maybe a good follow on would be to expose `minLength` and `maxLength` in `useArrayFieldInfo` to use within the array component. 