### PR TITLE
expose a FormFragment component for use in complex components

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,6 +1,9 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   preset: "ts-jest",
+  testTimeout: process.env.JEST_TIMEOUT
+    ? parseInt(process.env.JEST_TIMEOUT)
+    : undefined,
   testEnvironment: "jsdom",
   testPathIgnorePatterns: ["utils", "lib"],
   restoreMocks: true,

--- a/src/FieldContext.tsx
+++ b/src/FieldContext.tsx
@@ -104,21 +104,17 @@ function useContextProt(name: string) {
  *  </>
  * )
  */
-export function useTsController<FieldType extends any>({
-  name,
-}: {
-  name?: string;
-} = {}) {
+export function useTsController<FieldType extends any>() {
   const context = useContextProt("useTsController");
   type IsObj = FieldType extends Object ? true : false;
   type OnChangeValue = IsObj extends true
     ? DeepPartial<FieldType> | undefined
     : FieldType | undefined;
   // Just gives better types to useController
-  const controller = useController({
-    ...context,
-    name: name ?? context.name,
-  }) as unknown as Omit<UseControllerReturn, "field"> & {
+  const controller = useController(context) as unknown as Omit<
+    UseControllerReturn,
+    "field"
+  > & {
     field: Omit<UseControllerReturn["field"], "value" | "onChange"> & {
       value: FieldType | undefined;
       onChange: (value: OnChangeValue) => void;

--- a/src/FieldContext.tsx
+++ b/src/FieldContext.tsx
@@ -73,6 +73,11 @@ export function FieldContextProvider({
   );
 }
 
+export function useMaybeFieldName() {
+  const context = useContext(FieldContext);
+  return context?.name;
+}
+
 function useContextProt(name: string) {
   const context = useContext(FieldContext);
   if (!context)

--- a/src/FieldContext.tsx
+++ b/src/FieldContext.tsx
@@ -104,17 +104,21 @@ function useContextProt(name: string) {
  *  </>
  * )
  */
-export function useTsController<FieldType extends any>() {
+export function useTsController<FieldType extends any>({
+  name,
+}: {
+  name?: string;
+} = {}) {
   const context = useContextProt("useTsController");
   type IsObj = FieldType extends Object ? true : false;
   type OnChangeValue = IsObj extends true
     ? DeepPartial<FieldType> | undefined
     : FieldType | undefined;
   // Just gives better types to useController
-  const controller = useController(context) as any as Omit<
-    UseControllerReturn,
-    "field"
-  > & {
+  const controller = useController({
+    ...context,
+    name: name ?? context.name,
+  }) as unknown as Omit<UseControllerReturn, "field"> & {
     field: Omit<UseControllerReturn["field"], "value" | "onChange"> & {
       value: FieldType | undefined;
       onChange: (value: OnChangeValue) => void;

--- a/src/__tests__/createSchemaForm.test.tsx
+++ b/src/__tests__/createSchemaForm.test.tsx
@@ -1916,14 +1916,11 @@ describe("createSchemaForm", () => {
       const numberNodes = screen.queryByTestId(defaultNumberInputTestId);
       expect(numberNodes).toBeInTheDocument();
       expect(numberNodes).toHaveDisplayValue("4");
-      screen
-        .queryAllByTestId(errorMessageTestId)
-        .forEach((node) => expect(node).toBeEmptyDOMElement());
+      expect(screen.queryAllByTestId(errorMessageTestId)).toHaveLength(0);
       expect(mockOnSubmit).toHaveBeenCalledWith(defaultValues);
     });
     it("should allow deep rendering", async () => {
       const mockOnSubmit = jest.fn();
-      debugger;
       function ComplexField({ complexProp1 }: { complexProp1: boolean }) {
         const {
           field: { value },
@@ -1999,10 +1996,7 @@ describe("createSchemaForm", () => {
       await userEvent.click(button);
       // this rerender is currently needed because setError seemingly doesn't rerender the component using useController
       rerender(form);
-      screen.debug();
-      screen
-        .queryAllByTestId(errorMessageTestId)
-        .forEach((node) => expect(node).toBeEmptyDOMElement());
+      expect(screen.queryAllByTestId(errorMessageTestId)).toHaveLength(0);
       expect(mockOnSubmit).toHaveBeenCalledWith({
         ...defaultValues,
         nestedField: {
@@ -2108,9 +2102,7 @@ describe("createSchemaForm", () => {
       expect(basicNodes[2]).toHaveDisplayValue("4");
       expect(basicNodes[1]).toHaveDisplayValue(addedValue.str);
       expect(basicNodes[3]).toHaveDisplayValue(addedValue.num.toString());
-      screen
-        .queryAllByTestId(errorMessageTestId)
-        .forEach((node) => expect(node).toBeEmptyDOMElement());
+      expect(screen.queryAllByTestId(errorMessageTestId)).toHaveLength(0);
       expect(mockOnSubmit).toHaveBeenCalledWith({
         ...defaultValues,
         nestedField: [...defaultValues.nestedField, addedValue],
@@ -2203,9 +2195,7 @@ describe("createSchemaForm", () => {
       expect(basicNodes[2]).toHaveDisplayValue("4");
       expect(basicNodes[1]).toHaveDisplayValue(addedValue.str);
       expect(basicNodes[3]).toHaveDisplayValue(addedValue.num.toString());
-      screen
-        .queryAllByTestId(errorMessageTestId)
-        .forEach((node) => expect(node).toBeEmptyDOMElement());
+      expect(screen.queryAllByTestId(errorMessageTestId)).toHaveLength(0);
       expect(mockOnSubmit).toHaveBeenCalledWith({
         ...defaultValues,
         nestedField: [...defaultValues.nestedField, addedValue],
@@ -2223,7 +2213,6 @@ describe("createSchemaForm", () => {
 
     it("should be able to split up and reorder complex schemas", async () => {
       const mockOnSubmit = jest.fn();
-      debugger;
       function ComplexField({}: { complexProp1: boolean }) {
         return (
           <div>
@@ -2291,9 +2280,7 @@ describe("createSchemaForm", () => {
       const booleanNodes = screen.queryByTestId(defaultBooleanInputTestId);
       expect(booleanNodes).toBeInTheDocument();
       expect(booleanNodes).toBeChecked();
-      screen
-        .queryAllByTestId(errorMessageTestId)
-        .forEach((node) => expect(node).toBeEmptyDOMElement());
+      expect(screen.queryAllByTestId(errorMessageTestId)).toHaveLength(0);
       expect(mockOnSubmit).toHaveBeenCalledWith(defaultValues);
     });
     it("should render recursive object schemas", async () => {
@@ -2419,9 +2406,7 @@ describe("createSchemaForm", () => {
       const numberNodes = screen.queryByTestId(defaultNumberInputTestId);
       expect(numberNodes).toBeInTheDocument();
       expect(numberNodes).toHaveDisplayValue("4");
-      screen
-        .queryAllByTestId(errorMessageTestId)
-        .forEach((node) => expect(node).toBeEmptyDOMElement());
+      expect(screen.queryAllByTestId(errorMessageTestId)).toHaveLength(0);
       expect(mockOnSubmit).toHaveBeenCalledWith(defaultValues);
     });
   });

--- a/src/__tests__/createSchemaForm.test.tsx
+++ b/src/__tests__/createSchemaForm.test.tsx
@@ -1920,9 +1920,9 @@ describe("createSchemaForm", () => {
         .forEach((node) => expect(node).toBeEmptyDOMElement());
       expect(mockOnSubmit).toHaveBeenCalledWith(defaultValues);
     });
-    it("should allow deep rendering", async () => {
+    fit("should allow deep rendering", async () => {
       const mockOnSubmit = jest.fn();
-
+      debugger;
       function ComplexField({}: { complexProp1: boolean }) {
         const {
           field: { value },
@@ -1978,22 +1978,38 @@ describe("createSchemaForm", () => {
         />
       );
       const { rerender } = render(form);
+
+      expect(screen.queryByText("Yay")).toBeInTheDocument();
+      const textNode = screen.queryByTestId(defaultTextInputTestId);
+      if (!textNode) {
+        throw new Error("textNode is null");
+      }
+      expect(textNode).toBeInTheDocument();
+      expect(textNode).toHaveDisplayValue("this");
+      await userEvent.type(textNode, "2");
+      expect(textNode).toHaveDisplayValue("this2");
+      const numberNodes = screen.queryByTestId(defaultNumberInputTestId);
+      expect(numberNodes).toBeInTheDocument();
+      expect(numberNodes).toHaveDisplayValue("4");
+
       const button = screen.getByText("submit");
       await userEvent.click(button);
       // this rerender is currently needed because setError seemingly doesn't rerender the component using useController
       rerender(form);
       screen.debug();
-      expect(screen.queryByText("Yay")).toBeInTheDocument();
-      const textNodes = screen.queryByTestId(defaultTextInputTestId);
-      expect(textNodes).toBeInTheDocument();
-      expect(textNodes).toHaveDisplayValue("this");
-      const numberNodes = screen.queryByTestId(defaultNumberInputTestId);
-      expect(numberNodes).toBeInTheDocument();
-      expect(numberNodes).toHaveDisplayValue("4");
       screen
         .queryAllByTestId(errorMessageTestId)
         .forEach((node) => expect(node).toBeEmptyDOMElement());
-      expect(mockOnSubmit).toHaveBeenCalledWith(defaultValues);
+      expect(mockOnSubmit).toHaveBeenCalledWith({
+        ...defaultValues,
+        nestedField: {
+          ...defaultValues.nestedField,
+          nestedLevel2: {
+            ...defaultValues.nestedField.nestedLevel2,
+            str: "this2",
+          },
+        },
+      });
     });
     //TODO: add props to the nested fields and not just custom props of the component
     it("should render dynamic arrays", async () => {

--- a/src/__tests__/utils/testForm.tsx
+++ b/src/__tests__/utils/testForm.tsx
@@ -13,7 +13,9 @@ export const errorMessageTestId = "error-message";
 
 export function ErrorMessage() {
   const { error } = useTsController();
-  return <div data-testid={errorMessageTestId}>{error?.errorMessage}</div>;
+  return !error ? null : (
+    <div data-testid={errorMessageTestId}>{error?.errorMessage}</div>
+  );
 }
 
 export function TextField(props: {

--- a/src/__tests__/utils/testForm.tsx
+++ b/src/__tests__/utils/testForm.tsx
@@ -3,8 +3,18 @@ import { Control, useController } from "react-hook-form";
 import { z } from "zod";
 import { createUniqueFieldSchema } from "../../createFieldSchema";
 import { createTsForm } from "../../createSchemaForm";
+import { useTsController } from "../../FieldContext";
 
 export const textFieldTestId = "text-field";
+export const defaultTextInputTestId = "text-input";
+export const defaultBooleanInputTestId = "boolean-input";
+export const defaultNumberInputTestId = "number-input";
+export const errorMessageTestId = "error-message";
+
+export function ErrorMessage() {
+  const { error } = useTsController();
+  return <div data-testid={errorMessageTestId}>{error?.errorMessage}</div>;
+}
 
 export function TextField(props: {
   control: Control<any>;
@@ -17,35 +27,72 @@ export function TextField(props: {
   const {
     field: { onChange, value },
   } = useController({ control: props.control, name: props.name });
+
   return (
     <div data-testid={textFieldTestId}>
       {label && <label>{label}</label>}
       <input
-        data-testid={props.testId}
+        name={props.name}
+        data-testid={props.testId || defaultTextInputTestId}
         onChange={(e) => {
           onChange(e.target.value);
         }}
         value={value ? value : ""}
         placeholder={placeholder}
       />
+      <ErrorMessage />
     </div>
   );
 }
 
-function BooleanField(props: {
+export function BooleanField(props: {
   control: Control<any>;
   name: string;
-  testId: string;
+  testId?: string;
 }) {
-  return <input data-testid={props.testId} />;
+  const {
+    field: { onChange, value },
+  } = useController({ control: props.control, name: props.name });
+  return (
+    <div>
+      <input
+        name={props.name}
+        data-testid={props.testId ?? defaultBooleanInputTestId}
+        type="checkbox"
+        checked={value}
+        onChange={(e) => {
+          onChange(e.target.checked);
+        }}
+      />
+      <ErrorMessage />
+    </div>
+  );
 }
 
-function NumberField(props: {
+export function NumberField(props: {
   control: Control<any>;
   name: string;
-  testId: string;
+  testId?: string;
+  suffix?: string;
 }) {
-  return <input data-testid={props.testId} />;
+  const {
+    field: { onChange, value },
+  } = useController({ control: props.control, name: props.name });
+  return (
+    <div>
+      <input
+        name={props.name}
+        data-testid={props.testId ?? defaultNumberInputTestId}
+        type="number"
+        value={value}
+        onChange={(e) => {
+          onChange(e.target.value);
+        }}
+      />
+      <div>{props.suffix}</div>
+      <ErrorMessage />
+    </div>
+  );
 }
 
 export const customFieldTestId = "custom";
@@ -59,6 +106,7 @@ function CustomTextField(props: {
   return (
     <div data-testid={customFieldTestId}>
       <input data-testid={props.testId} />
+      <ErrorMessage />
     </div>
   );
 }

--- a/src/createSchemaForm.tsx
+++ b/src/createSchemaForm.tsx
@@ -529,6 +529,7 @@ export function createTsFormAndFragment<
     renderAfter,
     renderBefore,
     children: CustomChildrenComponent,
+    name,
   }: RTFSharedFormProps<Mapping, SchemaType, PropsMapType> & {
     renderBefore?: (props: { submit?: () => void }) => ReactNode;
     renderAfter?: (props: { submit?: () => void }) => ReactNode;
@@ -640,7 +641,7 @@ export function createTsFormAndFragment<
             type,
             props as any,
             stringKey,
-            [namePrefix, stringKey].filter(Boolean).join("."),
+            [namePrefix, name, stringKey].filter(Boolean).join("."),
             getValues()[key]
           );
           return accum;

--- a/src/createSchemaForm.tsx
+++ b/src/createSchemaForm.tsx
@@ -623,7 +623,7 @@ export function createTsFormAndFragment<
     }
     const name = [namePrefix, stringifySchemaKey(schemaKey)]
       .filter(Boolean)
-      .join(".");
+      .join(typeof schemaKey === "number" ? "" : ".");
     return renderComponentForSchemaDeep(
       schema,
       props as any,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { createUniqueFieldSchema } from "./createFieldSchema";
-export { createTsForm } from "./createSchemaForm";
+export { createTsForm, createTsFormAndFragment } from "./createSchemaForm";
 export {
   useDescription,
   useReqDescription,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,5 +9,6 @@ export {
   useStringFieldInfo,
   useNumberFieldInfo,
   useDateFieldInfo,
+  useMaybeFieldName,
 } from "./FieldContext";
 export type { RTFSupportedZodTypes } from "./supportedZodTypes";

--- a/src/supportedZodTypes.ts
+++ b/src/supportedZodTypes.ts
@@ -15,6 +15,7 @@ import {
   ZodString,
   ZodTuple,
   ZodEffects,
+  ZodLazy,
 } from "zod";
 
 /**
@@ -39,4 +40,5 @@ export type RTFBaseZodType =
 export type RTFSupportedZodTypes =
   | RTFBaseZodType
   | ZodOptional<any>
-  | ZodNullable<any>;
+  | ZodNullable<any>
+  | ZodLazy<any>;

--- a/src/unwrap.tsx
+++ b/src/unwrap.tsx
@@ -12,17 +12,29 @@ import {
 } from "./createFieldSchema";
 import { RTFSupportedZodTypes } from "./supportedZodTypes";
 
-const unwrappable = new Set<z.ZodFirstPartyTypeKind>([
+const unwrappableTypes = [
   z.ZodFirstPartyTypeKind.ZodOptional,
   z.ZodFirstPartyTypeKind.ZodNullable,
   z.ZodFirstPartyTypeKind.ZodBranded,
   z.ZodFirstPartyTypeKind.ZodDefault,
-]);
+  z.ZodFirstPartyTypeKind.ZodLazy,
+] as const;
+const unwrappable = new Set(unwrappableTypes);
 
 export type UnwrappedRTFSupportedZodTypes = {
   type: RTFSupportedZodTypes;
   [HIDDEN_ID_PROPERTY]: string | null;
 };
+
+export function assertNever(x: never): never {
+  throw new Error("[assertNever] Unexpected value: " + x);
+}
+
+type UnwrappableType = (typeof unwrappableTypes)[number];
+
+function isUnwrappable(type: ZodFirstPartyTypeKind): type is UnwrappableType {
+  return unwrappable.has(type as UnwrappableType);
+}
 
 export function unwrap(
   type: RTFSupportedZodTypes
@@ -32,7 +44,7 @@ export function unwrap(
   let r = type;
   let unwrappedHiddenId: null | string = null;
 
-  while (unwrappable.has(r._def.typeName)) {
+  while (isUnwrappable(r._def.typeName)) {
     if (isSchemaWithHiddenProperties(r)) {
       unwrappedHiddenId = r._def[HIDDEN_ID_PROPERTY];
     }
@@ -51,6 +63,12 @@ export function unwrap(
         // @ts-ignore
         r = r._def.innerType;
         break;
+      case z.ZodFirstPartyTypeKind.ZodLazy:
+        // @ts-ignore
+        r = r._def.getter();
+        break;
+      default:
+        assertNever(r._def.typeName);
     }
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "resolveJsonModule": true,
+    // uncomment to see full errors!
+    // "noErrorTruncation": true,
     "jsx": "react"
   },
   "types": ["node", "jest", "@testing-library/jest-dom"],


### PR DESCRIPTION
@iway1 I think this approach might be more versatile (and better performance) than the recursive component walking I added. This lets you render whatever remaining piece of the form your component is responsible for reducing duplication but giving full control. 

This is close but still WIP needs at least:

- [x] write a few more tests for more complex cases
- [x] is real recursion possible with this?
- [x] is it ok for FormFragment's `name` prop to be an intermediate name, and should it be renamed?
- [x] should useTsContoller's new name prop follow the same pattern and derive the prefix from context? (are there cases where we need to be able to fully override the name prefix? i think not)
- [x] does form fragment need to be able to support non-object schemas? (aka what if I want to make a custom array field of type number(), should i be able to reuse FormFragment to render the number field? or maybe we expose a third component which is a wrapper around renderComponentForSchemaDeep for this case)

I think these are not necessary to merge
- [x] fix use of getValues() to also useWatch() (this won't always rerender IIRC, maybe it's why my error messages weren't rerendering) - tried this and it didn't fix
- [ ] might want to disable the previous recursion stuff we added or at least make the depth configurable and default to 0 (but that would be a breaking change, unless we're pretty sure no one but me is using it haha)
- [ ] pull the schema from the field controller hook (i think this already exists with `type` but isn't strongly typed). i'm not sure this is important since we will have to cast it's type regardless. It does bring up a point though. That these custom components don't "know' their own schema. They only are coupled to the schema in the mapping. That's kinda fine but it would be cool to think of a way to more strongly couple them

Thoughts?