### PR TITLE
fix unwrap for default, arrays of enums, and generally all unwrappables in every order we support

### DIFF
--- a/src/__tests__/unwrap.test.tsx
+++ b/src/__tests__/unwrap.test.tsx
@@ -60,4 +60,76 @@ describe("unwrap types", () => {
       }}
     />;
   });
+  it("should have the correct types for .default()", () => {
+    function TextField(_: { one: string }) {
+      return <div />;
+    }
+    const mapping = [[z.string(), TextField]] as const;
+
+    const Form = createTsForm(mapping);
+
+    <Form
+      onSubmit={(data) => {
+        data.optionalNullableString;
+      }}
+      schema={z.object({
+        optionalNullableString: z
+          .string()
+          .default("moo")
+          .describe("something")
+          .optional()
+          .nullable(),
+      })}
+      props={{
+        optionalNullableString: {
+          one: "One",
+        },
+      }}
+    />;
+  });
+  it("should have the correct types for .enum().array()", () => {
+    function TextField(_: { one: string }) {
+      return <div />;
+    }
+    const mapping = [
+      [z.enum(["placeholder"]).array(), TextField],
+      [z.enum(["placeholder"]), TextField],
+    ] as const;
+
+    const Form = createTsForm(mapping);
+
+    <Form
+      onSubmit={(data) => {
+        data.enumArray;
+        data.enum;
+      }}
+      schema={z.object({
+        // tests we can match despite having different enum than the mapping
+        enum: z.enum(["moo"]),
+        // tests we can match arrays of enums
+        enumArray: z.enum(["moo"]).array(),
+        // tests we can match the deepest possible combination of unwrappable things
+        enumArrayWithEverything: z
+          .enum(["moo"])
+          .optional()
+          .nullable()
+          .default("moo")
+          .array()
+          .optional()
+          .nullable()
+          .default(["moo"]),
+      })}
+      props={{
+        enumArrayWithEverything: {
+          one: "One",
+        },
+        enumArray: {
+          one: "One",
+        },
+        enum: {
+          one: "One",
+        },
+      }}
+    />;
+  });
 });

--- a/src/unwrap.tsx
+++ b/src/unwrap.tsx
@@ -93,7 +93,7 @@ export type UnwrapZodType<
   : T extends ZodOptional<any> | ZodNullable<any> | ZodDefault<any>
   ? UnwrapZodType<T["_def"]["innerType"], UnwrapPreviousLevel[Level]>
   : T extends ZodArray<any, any>
-  ? // allow another 4 levels of recursiion for the array
+  ? // allow another 3 levels of recursion for the array
     ZodArray<UnwrapZodType<T["element"], UnwrapMaxRecursionDepth>>
   : T extends ZodEnum<any>
   ? ZodEnum<any>


### PR DESCRIPTION
I noticed our unwrap types didn't work for .default() even though the runtime code did. I've also seen a bug where z.enum().array() doesn't match either (because we didn't unwrap the enum type of the array element). 

The solution to all of this (and a few other possible differences in order) was to make the unwrap recursive. However, the  type had a comment mentioning that previously that created a stack overflow. 

Turns out this is possible (and seems fast) as long as we limit the depth to the max number of unwraps we allow. Similar to what we did with the type recursion in PropType (but much much simpler here)

cc @brettzallen (for the default problem) @matasar-watershed  (cause the enum array problem)